### PR TITLE
multi-environments-kustomize - Use applyspec syntax

### DIFF
--- a/multi-environments-kustomize/README.md
+++ b/multi-environments-kustomize/README.md
@@ -266,7 +266,7 @@ gke_megan-dev4_us-east1-b_dev
   SYNCED   5e5cf84f
 ```
 
-14. **Switch to the `dev` cluster context.** Get namespaces to verify that the resources are synced - you should see the `foo-dev` namespace appear, synced from the `foo-config-dev` repo. 
+14. **Switch to the `dev` cluster context.** Get namespaces to verify that the resources are synced - you should see the `foo` namespace appear, synced from the `foo-config-dev` repo. 
 
 
 ```
@@ -278,14 +278,15 @@ Expected output:
 
 ```
 NAME                           STATUS   AGE
-config-management-monitoring   Active   86m
-config-management-system       Active   86m
-default                        Active   102m
-foo-dev                        Active   9m42s
-gke-connect                    Active   98m
-kube-node-lease                Active   102m
-kube-public                    Active   102m
-kube-system                    Active   102m
+config-management-monitoring   Active   2m7s
+config-management-system       Active   2m7s
+default                        Active   13m
+foo                            Active   98s
+gke-connect                    Active   12m
+kube-node-lease                Active   13m
+kube-public                    Active   13m
+kube-system                    Active   13m
+resource-group-system          Active   119s
 ```
 
 Congrats! You just set up automated config rendering for a dev and prod environment, across multiple Google Cloud projects and environments. 

--- a/multi-environments-kustomize/install-config/config-management-dev.yaml
+++ b/multi-environments-kustomize/install-config/config-management-dev.yaml
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 # [START anthos_config_management_multi_environments_kustomize_install_config_dev] 
-apiVersion: configmanagement.gke.io/v1
-kind: ConfigManagement
-metadata:
-  name: config-management
+applySpecVersion: 1
 spec:
-  git:
+  configSync:
+    enabled: true
+    sourceFormat: unstructured
     syncRepo: https://github.com/GITHUB_USERNAME/foo-config-dev/
     syncBranch: main
     secretType: none
     policyDir: "/"
-  sourceFormat: unstructured
+  policyController:
+    enabled: false
+  hierarchyController:
+    enabled: false
 # [END anthos_config_management_multi_environments_kustomize_install_config_dev] 

--- a/multi-environments-kustomize/install-config/config-management-prod.yaml
+++ b/multi-environments-kustomize/install-config/config-management-prod.yaml
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 # [START anthos_config_management_multi_environments_kustomize_install_config_prod] 
-apiVersion: configmanagement.gke.io/v1
-kind: ConfigManagement
-metadata:
-  name: config-management
+applySpecVersion: 1
 spec:
-  git:
-    syncRepo: https://github.com/GITHUB_USERNAME/foo-config-prod/
+  configSync:
+    enabled: true
+    sourceFormat: unstructured
+    syncRepo: https://github.com/askmeegs/foo-config-prod/
     syncBranch: main
     secretType: none
     policyDir: "/"
-  sourceFormat: unstructured
+  policyController:
+    enabled: false
+  hierarchyController:
+    enabled: false
 # [END anthos_config_management_multi_environments_kustomize_install_config_prod] 

--- a/multi-environments-kustomize/install-config/config-management-prod.yaml
+++ b/multi-environments-kustomize/install-config/config-management-prod.yaml
@@ -18,7 +18,7 @@ spec:
   configSync:
     enabled: true
     sourceFormat: unstructured
-    syncRepo: https://github.com/askmeegs/foo-config-prod/
+    syncRepo: https://github.com/GITHUB_USERNAME/foo-config-prod/
     syncBranch: main
     secretType: none
     policyDir: "/"


### PR DESCRIPTION
Update install to use applyspec instead of the Config Management CRD. 

https://cloud.google.com/anthos-config-management/docs/reference/gcloud-apply-fields#example_gcloud_apply_spec