### PR TITLE
Hello Namespace - update sync branch in CRD

### DIFF
--- a/hello-namespace/setup/hello-namespace/config-management.yaml
+++ b/hello-namespace/setup/hello-namespace/config-management.yaml
@@ -21,7 +21,7 @@ spec:
   clusterName: my-cluster
   git:
     syncRepo: git@github.com:<GITHUB-USERNAME>/anthos-config-management-samples.git
-    syncBranch: 1.0.0
+    syncBranch: main
     secretType: ssh
     policyDir: "hello-namespace/config-root"
 # [END anthos_config_management_hello_namespace_config_management] 


### PR DESCRIPTION
This repo uses `main` as default branch, not `1.0.0` as csp-config-management did.