### PR TITLE
cleanup: update the codeowners to prefer anthos-dpes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,5 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*                   @GoogleCloudPlatform/anthos-dpe
 *                   @bgrant0607 @haiyanmeng @janetkuo @karlkfi @Liujingfang1 @morgante @nan-yu @nicjjohns @selfmanagingresource
+*		    @GoogleCloudPlatform/anthos-dpe

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,5 +4,4 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-*                   @bgrant0607 @haiyanmeng @janetkuo @karlkfi @Liujingfang1 @morgante @nan-yu @nicjjohns @selfmanagingresource
-*		    @GoogleCloudPlatform/anthos-dpe
+*		    @GoogleCloudPlatform/anthos-dpe @bgrant0607 @haiyanmeng @janetkuo @karlkfi @Liujingfang1 @morgante @nan-yu @nicjjohns @selfmanagingresource


### PR DESCRIPTION
#### Fixes?
- Updating the CODEOWNER preferences to give more control for `anthos-dpes`, so they can review and merge PRs without having to wait on extra reviews
- If there are specific samples that need to go through other reviewers then we should add CODEOWNER rules targetting those specific samples instead of the whole repo