### PR TITLE
cleanup: adding DRIFT region tags to yaml and sh files

### DIFF
--- a/ci-app/acm-repo/cluster/deployment-must-have-owner.yaml
+++ b/ci-app/acm-repo/cluster/deployment-must-have-owner.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_app_deployment_must_have_owner]
+# [START anthosconfig_ci_app_deployment_must_have_owner]
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
@@ -25,4 +25,4 @@ spec:
     labels:
       - key: "owner"
     message: "Deployment objects should have an 'owner' label indicating who created them."
-# [END anthos_config_management_ci_app_deployment_must_have_owner]
+# [END anthosconfig_ci_app_deployment_must_have_owner]

--- a/ci-app/acm-repo/cluster/deployment-must-have-owner.yaml
+++ b/ci-app/acm-repo/cluster/deployment-must-have-owner.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START anthosconfig_ci_app_deployment_must_have_owner]
+# [START anthos_config_management_ci_app_deployment_must_have_owner]
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
@@ -25,4 +26,5 @@ spec:
     labels:
       - key: "owner"
     message: "Deployment objects should have an 'owner' label indicating who created them."
+# [END anthos_config_management_ci_app_deployment_must_have_owner]
 # [END anthosconfig_ci_app_deployment_must_have_owner]

--- a/ci-app/acm-repo/cluster/requiredlabels.yaml
+++ b/ci-app/acm-repo/cluster/requiredlabels.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_app_required_labels]
+# [START anthosconfig_ci_app_required_labels]
 apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
@@ -65,4 +65,4 @@ spec:
           def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
           msg := get_message(input.parameters, def_msg)
         }
-# [END anthos_config_management_ci_app_required_labels]
+# [END anthosconfig_ci_app_required_labels]

--- a/ci-app/acm-repo/system/repo.yaml
+++ b/ci-app/acm-repo/system/repo.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_app_repo]
+# [START anthosconfig_ci_app_repo]
 apiVersion: configmanagement.gke.io/v1
 kind: Repo
 metadata:
   name: repo
 spec:
   version: 1.0.0
-# [END anthos_config_management_ci_app_repo]
+# [END anthosconfig_ci_app_repo]

--- a/ci-app/app-repo/config/base/deployment.yaml
+++ b/ci-app/app-repo/config/base/deployment.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START anthosconfig_base_deployment_deployment_nginx_deployment]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,3 +34,4 @@ spec:
         image: nginx:1.14.2
         ports:
         - containerPort: 80
+# [END anthosconfig_base_deployment_deployment_nginx_deployment]

--- a/ci-app/app-repo/config/base/kustomization.yaml
+++ b/ci-app/app-repo/config/base/kustomization.yaml
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START anthosconfig_config_base_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - deployment.yaml
+# [END anthosconfig_config_base_kustomization_kustomization]

--- a/ci-app/app-repo/config/prod/kustomization.yaml
+++ b/ci-app/app-repo/config/prod/kustomization.yaml
@@ -4,14 +4,17 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http://www.apache.org/licenses/LICENSE-2.0
+#      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START anthosconfig_config_prod_kustomization_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../base
+# [END anthosconfig_config_prod_kustomization_kustomization]

--- a/ci-pipeline-unstructured/cloudbuild.yaml
+++ b/ci-pipeline-unstructured/cloudbuild.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_unstructured_cloud_build] 
+# [START anthosconfig_ci_pipeline_unstructured_cloud_build] 
 steps:
   # Grant read/write permissions to the workspace.
   - name: "bash"
@@ -30,4 +30,4 @@ steps:
   # Validate input configs against any OPA ConstraintTemplates and Constraints it finds in its input.
   - name: "gcr.io/config-management-release/policy-controller-validate"
     args: ["--input", "/workspace/config-source.yaml"]
-# [END anthos_config_management_ci_pipeline_unstructured_cloud_build] 
+# [END anthosconfig_ci_pipeline_unstructured_cloud_build] 

--- a/ci-pipeline-unstructured/config-root/configmap.yaml
+++ b/ci-pipeline-unstructured/config-root/configmap.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_unstructured_configmap] 
+# [START anthosconfig_ci_pipeline_unstructured_configmap] 
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -19,4 +19,4 @@ metadata:
   namespace: default
 data:
   private_key: sensitive data goes here
-# [END anthos_config_management_ci_pipeline_unstructured_configmap] 
+# [END anthosconfig_ci_pipeline_unstructured_configmap] 

--- a/ci-pipeline-unstructured/config-root/constraints/banned-key-constraint.yaml
+++ b/ci-pipeline-unstructured/config-root/constraints/banned-key-constraint.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_unstructured_no_secrets_in_configmap] 
+# [START anthosconfig_ci_pipeline_unstructured_no_secrets_in_configmap] 
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sBannedConfigMapKeysV1
 metadata:
@@ -26,4 +26,4 @@ spec:
   parameters:
     keys:
       - private_key
-# [END anthos_config_management_ci_pipeline_unstructured_no_secrets_in_configmap] 
+# [END anthosconfig_ci_pipeline_unstructured_no_secrets_in_configmap] 

--- a/ci-pipeline-unstructured/config-root/constraints/banned-key-template.yaml
+++ b/ci-pipeline-unstructured/config-root/constraints/banned-key-template.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_unstructured_banned_key_template] 
+# [START anthosconfig_ci_pipeline_unstructured_banned_key_template] 
 apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
@@ -40,4 +40,4 @@ spec:
           count(overlap) > 0
           val := sprintf("The following banned keys are being used in the config map: %v", [overlap])
         }
-# [END anthos_config_management_ci_pipeline_unstructured_banned_key_template] 
+# [END anthosconfig_ci_pipeline_unstructured_banned_key_template] 

--- a/ci-pipeline/cloudbuild.yaml
+++ b/ci-pipeline/cloudbuild.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_cloud_build]
+# [START anthosconfig_ci_pipeline_cloud_build]
 steps:
 # Generate the kubeconfig file needed to authenticate to the GKE cluster. The root user generates this file with restricted permissions.
 - name: 'gcr.io/cloud-builders/kubectl'
@@ -47,4 +47,4 @@ steps:
 # Validate input configs against any OPA ConstraintTemplates and Constraints it finds in its input.
 - name: 'gcr.io/config-management-release/policy-controller-validate'
   args: ['--input', '/workspace/config-source.yaml']
-# [END anthos_config_management_ci_pipeline_cloud_build]
+# [END anthosconfig_ci_pipeline_cloud_build]

--- a/ci-pipeline/config-root/cluster/fulfillmentcenter-crd.yaml
+++ b/ci-pipeline/config-root/cluster/fulfillmentcenter-crd.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_fulfillment_center]
+# [START anthosconfig_ci_pipeline_fulfillment_center]
 # Updated Custom Resource Definition for an Anvil.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -53,4 +53,4 @@ spec:
     plural: fulfillmentcenters
     singular: fulfillmentcenter
     kind: FulfillmentCenter
-# [END anthos_config_management_ci_pipeline_fulfillment_center]
+# [END anthosconfig_ci_pipeline_fulfillment_center]

--- a/ci-pipeline/config-root/cluster/namespace-reader-clusterrole.yaml
+++ b/ci-pipeline/config-root/cluster/namespace-reader-clusterrole.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_namespace_reader]
+# [START anthosconfig_ci_pipeline_namespace_reader]
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,4 +20,4 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "watch", "list"]
-# [END anthos_config_management_ci_pipeline_namespace_reader]
+# [END anthosconfig_ci_pipeline_namespace_reader]

--- a/ci-pipeline/config-root/cluster/namespace-reader-clusterrolebinding.yaml
+++ b/ci-pipeline/config-root/cluster/namespace-reader-clusterrolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_namespace_readers]
+# [START anthosconfig_ci_pipeline_namespace_readers]
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -24,4 +24,4 @@ roleRef:
   kind: ClusterRole
   name: namespace-reader
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_ci_pipeline_namespace_readers]
+# [END anthosconfig_ci_pipeline_namespace_readers]

--- a/ci-pipeline/config-root/cluster/pod-creator-clusterrole.yaml
+++ b/ci-pipeline/config-root/cluster/pod-creator-clusterrole.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_pod_creator]
+# [START anthosconfig_ci_pipeline_pod_creator]
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,4 +21,4 @@ rules:
   resources: ["pods"]
   verbs:
   - "*"
-# [END anthos_config_management_ci_pipeline_pod_creator]
+# [END anthosconfig_ci_pipeline_pod_creator]

--- a/ci-pipeline/config-root/cluster/pod-security-policy.yaml
+++ b/ci-pipeline/config-root/cluster/pod-security-policy.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_pod_security_policy]
+# [START anthosconfig_ci_pipeline_pod_security_policy]
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -28,4 +28,4 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
-# [END anthos_config_management_ci_pipeline_pod_security_policy]
+# [END anthosconfig_ci_pipeline_pod_security_policy]

--- a/ci-pipeline/config-root/cluster/required-labels-constraint.yaml
+++ b/ci-pipeline/config-root/cluster/required-labels-constraint.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_all_must_have_cost_center]
+# [START anthosconfig_ci_pipeline_all_must_have_cost_center]
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
@@ -26,4 +26,4 @@ spec:
     labels:
       - key: cost-center
         allowedRegex: "^[a-zA-Z]+.foo-corp.com$"
-# [END anthos_config_management_ci_pipeline_all_must_have_cost_center]
+# [END anthosconfig_ci_pipeline_all_must_have_cost_center]

--- a/ci-pipeline/config-root/cluster/required-labels-template.yaml
+++ b/ci-pipeline/config-root/cluster/required-labels-template.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_k8s_required_labels]
+# [START anthosconfig_ci_pipeline_k8s_required_labels]
 apiVersion: templates.gatekeeper.sh/v1beta1
 kind: ConstraintTemplate
 metadata:
@@ -68,4 +68,4 @@ spec:
           def_msg := sprintf("Label <%v: %v> does not satisfy allowed regex: %v", [key, value, expected.allowedRegex])
           msg := get_message(input.parameters, def_msg)
         }
-# [END anthos_config_management_ci_pipeline_k8s_required_labels]
+# [END anthosconfig_ci_pipeline_k8s_required_labels]

--- a/ci-pipeline/config-root/namespaces/audit/namespace.yaml
+++ b/ci-pipeline/config-root/namespaces/audit/namespace.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_audit]
+# [START anthosconfig_ci_pipeline_audit]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: audit
   labels:
     cost-center: "audit.foo-corp.com"
-# [END anthos_config_management_ci_pipeline_audit]
+# [END anthosconfig_ci_pipeline_audit]

--- a/ci-pipeline/config-root/namespaces/online/shipping-app-backend/pod-creator-rolebinding.yaml
+++ b/ci-pipeline/config-root/namespaces/online/shipping-app-backend/pod-creator-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_pod_creators]
+# [START anthosconfig_ci_pipeline_pod_creators]
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -24,4 +24,4 @@ roleRef:
   kind: ClusterRole
   name: pod-creator
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_ci_pipeline_pod_creators]
+# [END anthosconfig_ci_pipeline_pod_creators]

--- a/ci-pipeline/config-root/namespaces/online/shipping-app-backend/quota.yaml
+++ b/ci-pipeline/config-root/namespaces/online/shipping-app-backend/quota.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_quota]
+# [START anthosconfig_ci_pipeline_quota]
 kind: ResourceQuota
 apiVersion: v1
 metadata:
@@ -21,4 +21,4 @@ spec:
     pods: "3"
     cpu: "1"
     memory: 1Gi
-# [END anthos_config_management_ci_pipeline_quota]
+# [END anthosconfig_ci_pipeline_quota]

--- a/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-dev/job-creator-role.yaml
+++ b/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-dev/job-creator-role.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_shipping_dev_job_creator]
+# [START anthosconfig_ci_pipeline_shipping_dev_job_creator]
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,4 +21,4 @@ rules:
   resources: ["jobs"]
   verbs:
    - "*"
-# [END anthos_config_management_ci_pipeline_shipping_dev_job_creator]
+# [END anthosconfig_ci_pipeline_shipping_dev_job_creator]

--- a/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-dev/job-creator-rolebinding.yaml
+++ b/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-dev/job-creator-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_shipping_dev_job_creators]
+# [START anthosconfig_ci_pipeline_shipping_dev_job_creators]
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -24,4 +24,4 @@ roleRef:
   kind: Role
   name: job-creator
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_ci_pipeline_shipping_dev_job_creators]
+# [END anthosconfig_ci_pipeline_shipping_dev_job_creators]

--- a/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-dev/namespace.yaml
+++ b/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-dev/namespace.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_shipping_dev_namespace]
+# [START anthosconfig_ci_pipeline_shipping_dev_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: shipping-dev
   labels:
     cost-center: "shipping.foo-corp.com"
-# [END anthos_config_management_ci_pipeline_shipping_dev_namespace]
+# [END anthosconfig_ci_pipeline_shipping_dev_namespace]

--- a/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-prod/fulfillmentcenter.yaml
+++ b/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-prod/fulfillmentcenter.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_shipping_prod_fulfillment_center]
+# [START anthosconfig_ci_pipeline_shipping_prod_fulfillment_center]
 kind: FulfillmentCenter
 apiVersion: foo-corp.com/v1
 metadata:
   name: production
 spec:
   address: "100 Industry St."
-# [END anthos_config_management_ci_pipeline_shipping_prod_fulfillment_center]
+# [END anthosconfig_ci_pipeline_shipping_prod_fulfillment_center]

--- a/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-prod/namespace.yaml
+++ b/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-prod/namespace.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_shipping_prod_namespace]
+# [START anthosconfig_ci_pipeline_shipping_prod_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -20,4 +20,4 @@ metadata:
     env: prod
   annotations:
     audit: "true"
-# [END anthos_config_management_ci_pipeline_shipping_prod_namespace]
+# [END anthosconfig_ci_pipeline_shipping_prod_namespace]

--- a/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-staging/fulfillmentcenter.yaml
+++ b/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-staging/fulfillmentcenter.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_shipping_staging_fulfillment_center]
+# [START anthosconfig_ci_pipeline_shipping_staging_fulfillment_center]
 kind: FulfillmentCenter
 apiVersion: foo-corp.com/v1
 metadata:
   name: staging
 spec:
   address: "100 Main St."
-# [END anthos_config_management_ci_pipeline_shipping_staging_fulfillment_center]
+# [END anthosconfig_ci_pipeline_shipping_staging_fulfillment_center]

--- a/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-staging/namespace.yaml
+++ b/ci-pipeline/config-root/namespaces/online/shipping-app-backend/shipping-staging/namespace.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_shipping_staging_namespace]
+# [START anthosconfig_ci_pipeline_shipping_staging_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: shipping-staging
   labels:
     cost-center: "shipping.foo-corp.com"
-# [END anthos_config_management_ci_pipeline_shipping_staging_namespace]
+# [END anthosconfig_ci_pipeline_shipping_staging_namespace]

--- a/ci-pipeline/config-root/namespaces/sre-rolebinding.yaml
+++ b/ci-pipeline/config-root/namespaces/sre-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_sre_admin]
+# [START anthosconfig_ci_pipeline_sre_admin]
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -26,4 +26,4 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_ci_pipeline_sre_admin]
+# [END anthosconfig_ci_pipeline_sre_admin]

--- a/ci-pipeline/config-root/namespaces/sre-supported-selector.yaml
+++ b/ci-pipeline/config-root/namespaces/sre-supported-selector.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_sre_supported]
+# [START anthosconfig_ci_pipeline_sre_supported]
 kind: NamespaceSelector
 apiVersion: configmanagement.gke.io/v1
 metadata:
@@ -20,4 +20,4 @@ spec:
   selector:
     matchLabels:
       env: prod
-# [END anthos_config_management_ci_pipeline_sre_supported]
+# [END anthosconfig_ci_pipeline_sre_supported]

--- a/ci-pipeline/config-root/namespaces/viewers-rolebinding.yaml
+++ b/ci-pipeline/config-root/namespaces/viewers-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_viewers]
+# [START anthosconfig_ci_pipeline_viewers]
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -24,4 +24,4 @@ roleRef:
   kind: ClusterRole
   name: view
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_ci_pipeline_viewers]
+# [END anthosconfig_ci_pipeline_viewers]

--- a/ci-pipeline/config-root/system/repo.yaml
+++ b/ci-pipeline/config-root/system/repo.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_ci_pipeline_repo]
+# [START anthosconfig_ci_pipeline_repo]
 apiVersion: configmanagement.gke.io/v1
 kind: Repo
 metadata:
   name: repo
 spec:
   version: 1.0.0
-# [END anthos_config_management_ci_pipeline_repo]
+# [END anthosconfig_ci_pipeline_repo]

--- a/config-sync-quickstart/monorepo/root/clusterrole-namespace-reader.yaml
+++ b/config-sync-quickstart/monorepo/root/clusterrole-namespace-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_cluster_role_namespace_reader] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_cluster_role_namespace_reader] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,4 +20,4 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "watch", "list"]
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_cluster_role_namespace_reader] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_cluster_role_namespace_reader] 

--- a/config-sync-quickstart/monorepo/root/clusterrole-webstore-admin.yaml
+++ b/config-sync-quickstart/monorepo/root/clusterrole-webstore-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_cluster_role_webstore_admin] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_cluster_role_webstore_admin] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,4 +21,4 @@ rules:
   resources: ["webstores"]
   verbs:
   - "*"
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_cluster_role_webstore_admin] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_cluster_role_webstore_admin] 

--- a/config-sync-quickstart/monorepo/root/crd-anvil.yaml
+++ b/config-sync-quickstart/monorepo/root/crd-anvil.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_custom_resource_anvil] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_custom_resource_anvil] 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -56,4 +56,4 @@ spec:
     plural: anvils
     singular: anvil
     kind: Anvil
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_custom_resource_anvil] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_custom_resource_anvil] 

--- a/config-sync-quickstart/monorepo/root/crd-webstore.yaml
+++ b/config-sync-quickstart/monorepo/root/crd-webstore.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_custom_resource_webstore] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_custom_resource_webstore] 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -59,4 +59,4 @@ spec:
     singular: webstore
     kind: WebStore
   preserveUnknownFields: false
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_custom_resource_webstore] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_custom_resource_webstore] 

--- a/config-sync-quickstart/monorepo/root/namespaces/acm-monitor/acm-prometheus-config.yaml
+++ b/config-sync-quickstart/monorepo/root/namespaces/acm-monitor/acm-prometheus-config.yaml
@@ -11,15 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_service_account_prometheus_acm] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_service_account_prometheus_acm] 
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus-acm
   namespace: monitoring
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_service_account_prometheus_acm] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_service_account_prometheus_acm] 
 ---
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_cluster_role_prometheus_acm] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_cluster_role_prometheus_acm] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -38,9 +38,9 @@ rules:
   verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_cluster_role_prometheus_acm] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_cluster_role_prometheus_acm] 
 ---
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_cluster_role_binding_prometheus_acm] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_cluster_role_binding_prometheus_acm] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -53,9 +53,9 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-acm
   namespace: monitoring
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_cluster_role_binding_prometheus_acm] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_cluster_role_binding_prometheus_acm] 
 ---
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_prometheus] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_prometheus] 
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
@@ -77,9 +77,9 @@ spec:
   resources:
     requests:
       memory: 400Mi
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_prometheus] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_prometheus] 
 ---
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_service] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_service] 
 apiVersion: v1
 kind: Service
 metadata:
@@ -98,9 +98,9 @@ spec:
   selector:
     app: prometheus
     prometheus: acm
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_service] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_service] 
 ---
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_service_monitor] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_service_monitor] 
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -121,4 +121,4 @@ spec:
   endpoints:
   - port: metrics
     interval: 10s
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_service_monitor] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_service_monitor] 

--- a/config-sync-quickstart/monorepo/root/namespaces/acm-monitor/namespace-monitoring.yaml
+++ b/config-sync-quickstart/monorepo/root/namespaces/acm-monitor/namespace-monitoring.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_namespace_monitoring] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_namespace_monitoring] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_acm_monitor_namespace_monitoring] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_acm_monitor_namespace_monitoring] 

--- a/config-sync-quickstart/monorepo/root/namespaces/acm-monitor/prometheus-operator.yaml
+++ b/config-sync-quickstart/monorepo/root/namespaces/acm-monitor/prometheus-operator.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_alertmanagerconfigs_monitoring_coreos_com]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2443,7 +2445,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_alertmanagerconfigs_monitoring_coreos_com]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_alertmanagers_monitoring_coreos_com]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7334,7 +7338,9 @@ spec:
     served: true
     storage: true
     subresources: {}
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_alertmanagers_monitoring_coreos_com]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_podmonitors_monitoring_coreos_com]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7781,7 +7787,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_podmonitors_monitoring_coreos_com]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_probes_monitoring_coreos_com]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -8204,7 +8212,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_probes_monitoring_coreos_com]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_prometheuses_monitoring_coreos_com]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14765,7 +14775,9 @@ spec:
     served: true
     storage: true
     subresources: {}
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_prometheuses_monitoring_coreos_com]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_prometheusrules_monitoring_coreos_com]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14855,7 +14867,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_prometheusrules_monitoring_coreos_com]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_servicemonitors_monitoring_coreos_com]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15325,7 +15339,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_servicemonitors_monitoring_coreos_com]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_thanosrulers_monitoring_coreos_com]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -20351,7 +20367,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_thanosrulers_monitoring_coreos_com]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_serviceaccount_prometheus_operator]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -20361,7 +20379,9 @@ metadata:
     app.kubernetes.io/version: 0.47.0
   name: prometheus-operator
   namespace: monitoring
+# [END anthosconfig_acm_monitor_prometheus_operator_serviceaccount_prometheus_operator]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_clusterrole_prometheus_operator]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -20441,7 +20461,9 @@ rules:
   - get
   - list
   - watch
+# [END anthosconfig_acm_monitor_prometheus_operator_clusterrole_prometheus_operator]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_clusterrolebinding_prometheus_operator]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -20458,7 +20480,9 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-operator
   namespace: monitoring
+# [END anthosconfig_acm_monitor_prometheus_operator_clusterrolebinding_prometheus_operator]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_service_prometheus_operator]
 apiVersion: v1
 kind: Service
 metadata:
@@ -20477,7 +20501,9 @@ spec:
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
+# [END anthosconfig_acm_monitor_prometheus_operator_service_prometheus_operator]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_deployment_prometheus_operator]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20524,3 +20550,4 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: prometheus-operator
+# [END anthosconfig_acm_monitor_prometheus_operator_deployment_prometheus_operator]

--- a/config-sync-quickstart/monorepo/root/namespaces/gamestore/configmap-inventory.yaml
+++ b/config-sync-quickstart/monorepo/root/namespaces/gamestore/configmap-inventory.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_gamestore_configmap_store_inventory] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_gamestore_configmap_store_inventory] 
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,4 +23,4 @@ data:
   single_player: "20"
   cooperative: "60"
   competitive: "300"
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_gamestore_configmap_store_inventory] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_gamestore_configmap_store_inventory] 

--- a/config-sync-quickstart/monorepo/root/namespaces/gamestore/namespace-gamestore.yaml
+++ b/config-sync-quickstart/monorepo/root/namespaces/gamestore/namespace-gamestore.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_gamestore_namespace] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_gamestore_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: gamestore
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_gamestore_namespace] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_gamestore_namespace] 

--- a/config-sync-quickstart/monorepo/root/namespaces/gamestore/webstore.yaml
+++ b/config-sync-quickstart/monorepo/root/namespaces/gamestore/webstore.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_monorepo_root_gamestore_webstore] 
+# [START anthosconfig_config_sync_quickstart_monorepo_root_gamestore_webstore] 
 kind: WebStore
 apiVersion: marketplace.com/v2
 metadata:
@@ -20,4 +20,4 @@ metadata:
 spec:
   product: "boardgames"
   employees: 5
-# [END anthos_config_management_config_sync_quickstart_monorepo_root_gamestore_webstore] 
+# [END anthosconfig_config_sync_quickstart_monorepo_root_gamestore_webstore] 

--- a/config-sync-quickstart/multirepo/namespaces/gamestore/configmap-inventory.yaml
+++ b/config-sync-quickstart/multirepo/namespaces/gamestore/configmap-inventory.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_gamestore_configmap_inventory] 
+# [START anthosconfig_config_sync_quickstart_multirepo_gamestore_configmap_inventory] 
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,4 +23,4 @@ data:
   single_player: "20"
   cooperative: "60"
   competitive: "300"
-# [END anthos_config_management_config_sync_quickstart_multirepo_gamestore_configmap_inventory] 
+# [END anthosconfig_config_sync_quickstart_multirepo_gamestore_configmap_inventory] 

--- a/config-sync-quickstart/multirepo/namespaces/gamestore/webstore.yaml
+++ b/config-sync-quickstart/multirepo/namespaces/gamestore/webstore.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_gamestore_webstore] 
+# [START anthosconfig_config_sync_quickstart_multirepo_gamestore_webstore] 
 kind: WebStore
 apiVersion: marketplace.com/v2
 metadata:
@@ -20,4 +20,4 @@ metadata:
 spec:
   product: "boardgames"
   employees: 5
-# [END anthos_config_management_config_sync_quickstart_multirepo_gamestore_webstore] 
+# [END anthosconfig_config_sync_quickstart_multirepo_gamestore_webstore] 

--- a/config-sync-quickstart/multirepo/root/acm-monitor/acm-prometheus-config.yaml
+++ b/config-sync-quickstart/multirepo/root/acm-monitor/acm-prometheus-config.yaml
@@ -11,15 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_service_account] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_service_account] 
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus-acm
   namespace: monitoring
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_service_account] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_service_account] 
 ---
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_cluster_role] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_cluster_role] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -38,9 +38,9 @@ rules:
   verbs: ["get"]
 - nonResourceURLs: ["/metrics"]
   verbs: ["get"]
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_cluster_role] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_cluster_role] 
 ---
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_cluster_role_binding] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_cluster_role_binding] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -53,9 +53,9 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-acm
   namespace: monitoring
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_cluster_role_binding] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_cluster_role_binding] 
 ---
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_prometheus] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_prometheus] 
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
@@ -77,9 +77,9 @@ spec:
   resources:
     requests:
       memory: 400Mi
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_prometheus] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_prometheus] 
 ---
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_service] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_service] 
 apiVersion: v1
 kind: Service
 metadata:
@@ -98,9 +98,9 @@ spec:
   selector:
     app: prometheus
     prometheus: acm
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_service] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_service] 
 ---
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_service_monitor] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_service_monitor] 
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -121,4 +121,4 @@ spec:
   endpoints:
   - port: metrics
     interval: 10s
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_service_monitor] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_service_monitor] 

--- a/config-sync-quickstart/multirepo/root/acm-monitor/namespace-monitoring.yaml
+++ b/config-sync-quickstart/multirepo/root/acm-monitor/namespace-monitoring.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_namespace] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: monitoring
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_acm_monitor_namespace] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_acm_monitor_namespace] 

--- a/config-sync-quickstart/multirepo/root/acm-monitor/prometheus-operator.yaml
+++ b/config-sync-quickstart/multirepo/root/acm-monitor/prometheus-operator.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_alertmanagerconfigs_monitoring_coreos_com2]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -2443,7 +2445,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_alertmanagerconfigs_monitoring_coreos_com2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_alertmanagers_monitoring_coreos_com2]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7334,7 +7338,9 @@ spec:
     served: true
     storage: true
     subresources: {}
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_alertmanagers_monitoring_coreos_com2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_podmonitors_monitoring_coreos_com2]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -7781,7 +7787,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_podmonitors_monitoring_coreos_com2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_probes_monitoring_coreos_com2]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -8204,7 +8212,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_probes_monitoring_coreos_com2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_prometheuses_monitoring_coreos_com2]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14765,7 +14775,9 @@ spec:
     served: true
     storage: true
     subresources: {}
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_prometheuses_monitoring_coreos_com2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_prometheusrules_monitoring_coreos_com2]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -14855,7 +14867,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_prometheusrules_monitoring_coreos_com2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_servicemonitors_monitoring_coreos_com2]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -15325,7 +15339,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_servicemonitors_monitoring_coreos_com2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_thanosrulers_monitoring_coreos_com2]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -20351,7 +20367,9 @@ spec:
         type: object
     served: true
     storage: true
+# [END anthosconfig_acm_monitor_prometheus_operator_customresourcedefinition_thanosrulers_monitoring_coreos_com2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_serviceaccount_prometheus_operator2]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -20361,7 +20379,9 @@ metadata:
     app.kubernetes.io/version: 0.47.0
   name: prometheus-operator
   namespace: monitoring
+# [END anthosconfig_acm_monitor_prometheus_operator_serviceaccount_prometheus_operator2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_clusterrole_prometheus_operator2]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -20441,7 +20461,9 @@ rules:
   - get
   - list
   - watch
+# [END anthosconfig_acm_monitor_prometheus_operator_clusterrole_prometheus_operator2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_clusterrolebinding_prometheus_operator2]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -20458,7 +20480,9 @@ subjects:
 - kind: ServiceAccount
   name: prometheus-operator
   namespace: monitoring
+# [END anthosconfig_acm_monitor_prometheus_operator_clusterrolebinding_prometheus_operator2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_service_prometheus_operator2]
 apiVersion: v1
 kind: Service
 metadata:
@@ -20477,7 +20501,9 @@ spec:
   selector:
     app.kubernetes.io/component: controller
     app.kubernetes.io/name: prometheus-operator
+# [END anthosconfig_acm_monitor_prometheus_operator_service_prometheus_operator2]
 ---
+# [START anthosconfig_acm_monitor_prometheus_operator_deployment_prometheus_operator2]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20524,3 +20550,4 @@ spec:
         runAsNonRoot: true
         runAsUser: 65534
       serviceAccountName: prometheus-operator
+# [END anthosconfig_acm_monitor_prometheus_operator_deployment_prometheus_operator2]

--- a/config-sync-quickstart/multirepo/root/clusterrole-namespace-reader.yaml
+++ b/config-sync-quickstart/multirepo/root/clusterrole-namespace-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_cluster_role_namespace_reader] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_cluster_role_namespace_reader] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,4 +20,4 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "watch", "list"]
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_cluster_role_namespace_reader] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_cluster_role_namespace_reader] 

--- a/config-sync-quickstart/multirepo/root/clusterrole-webstore-admin.yaml
+++ b/config-sync-quickstart/multirepo/root/clusterrole-webstore-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_cluster_role_webstore_admin] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_cluster_role_webstore_admin] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,4 +21,4 @@ rules:
   resources: ["webstores"]
   verbs:
   - "*"
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_cluster_role_webstore_admin] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_cluster_role_webstore_admin] 

--- a/config-sync-quickstart/multirepo/root/crd-anvil.yaml
+++ b/config-sync-quickstart/multirepo/root/crd-anvil.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_custom_resource_anvil] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_custom_resource_anvil] 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -56,4 +56,4 @@ spec:
     plural: anvils
     singular: anvil
     kind: Anvil
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_custom_resource_anvil] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_custom_resource_anvil] 

--- a/config-sync-quickstart/multirepo/root/crd-webstore.yaml
+++ b/config-sync-quickstart/multirepo/root/crd-webstore.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_custom_resource_webstore] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_custom_resource_webstore] 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -59,4 +59,4 @@ spec:
     singular: webstore
     kind: WebStore
   preserveUnknownFields: false
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_custom_resource_webstore] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_custom_resource_webstore] 

--- a/config-sync-quickstart/multirepo/root/namespace-gamestore.yaml
+++ b/config-sync-quickstart/multirepo/root/namespace-gamestore.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_namespace_gamestore] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_namespace_gamestore] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: gamestore
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_namespace_gamestore] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_namespace_gamestore] 

--- a/config-sync-quickstart/multirepo/root/reposync-gamestore.yaml
+++ b/config-sync-quickstart/multirepo/root/reposync-gamestore.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_repo_sync] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_repo_sync] 
 apiVersion: configsync.gke.io/v1alpha1
 kind: RepoSync
 metadata:
@@ -34,4 +34,4 @@ spec:
     # Refer to a Secret you create to hold the private key, cookiefile, or token.
     # secretRef:
     #   name: SECRET_NAME
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_repo_sync] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_repo_sync] 

--- a/config-sync-quickstart/multirepo/root/rolebinding-gamestore-admin.yaml
+++ b/config-sync-quickstart/multirepo/root/rolebinding-gamestore-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_role_binding_gamestore_admin] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_role_binding_gamestore_admin] 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,4 +25,4 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_role_binding_gamestore_admin] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_role_binding_gamestore_admin] 

--- a/config-sync-quickstart/multirepo/root/rolebinding-gamestore-webstore-admin.yaml
+++ b/config-sync-quickstart/multirepo/root/rolebinding-gamestore-webstore-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_config_sync_quickstart_multirepo_root_role_binding_gamestore_webstore_admin] 
+# [START anthosconfig_config_sync_quickstart_multirepo_root_role_binding_gamestore_webstore_admin] 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,4 +25,4 @@ roleRef:
   kind: ClusterRole
   name: webstore-admin
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_config_sync_quickstart_multirepo_root_role_binding_gamestore_webstore_admin] 
+# [END anthosconfig_config_sync_quickstart_multirepo_root_role_binding_gamestore_webstore_admin] 

--- a/crds/configmanagement_v1_configmanagement.yaml
+++ b/crds/configmanagement_v1_configmanagement.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_crd]
+# [START anthosconfig_crd]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -366,4 +366,4 @@ status:
     plural: ""
   conditions: []
   storedVersions: []
-# [END anthos_config_management_crd]
+# [END anthosconfig_crd]

--- a/foo-corp/cluster/fulfillmentcenter-crd.yaml
+++ b/foo-corp/cluster/fulfillmentcenter-crd.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # Updated Custom Resource Definition for an Anvil.
-# [START anthos_config_management_foo_corp_fulfillment_center] 
+# [START anthosconfig_foo_corp_fulfillment_center] 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -53,4 +53,4 @@ spec:
     plural: fulfillmentcenters
     singular: fulfillmentcenter
     kind: FulfillmentCenter
-# [END anthos_config_management_foo_corp_fulfillment_center] 
+# [END anthosconfig_foo_corp_fulfillment_center] 

--- a/foo-corp/cluster/namespace-reader-clusterrole.yaml
+++ b/foo-corp/cluster/namespace-reader-clusterrole.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_namespace_reader_cluster_role] 
+# [START anthosconfig_foo_corp_namespace_reader_cluster_role] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,4 +20,4 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "watch", "list"]
-# [END anthos_config_management_foo_corp_namespace_reader_cluster_role] 
+# [END anthosconfig_foo_corp_namespace_reader_cluster_role] 

--- a/foo-corp/cluster/namespace-reader-clusterrolebinding.yaml
+++ b/foo-corp/cluster/namespace-reader-clusterrolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_namespace_readers_cluster_role_binding] 
+# [START anthosconfig_foo_corp_namespace_readers_cluster_role_binding] 
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -24,4 +24,4 @@ roleRef:
   kind: ClusterRole
   name: namespace-reader
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_foo_corp_namespace_readers_cluster_role_binding] 
+# [END anthosconfig_foo_corp_namespace_readers_cluster_role_binding] 

--- a/foo-corp/cluster/pod-creator-clusterrole.yaml
+++ b/foo-corp/cluster/pod-creator-clusterrole.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_pod_creator_cluster_role] 
+# [START anthosconfig_foo_corp_pod_creator_cluster_role] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,4 +21,4 @@ rules:
   resources: ["pods"]
   verbs:
   - "*"
-# [END anthos_config_management_foo_corp_pod_creator_cluster_role] 
+# [END anthosconfig_foo_corp_pod_creator_cluster_role] 

--- a/foo-corp/cluster/pod-security-policy.yaml
+++ b/foo-corp/cluster/pod-security-policy.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_pod_security_policy] 
+# [START anthosconfig_foo_corp_pod_security_policy] 
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -28,4 +28,4 @@ spec:
     rule: RunAsAny
   volumes:
   - '*'
-# [END anthos_config_management_foo_corp_pod_security_policy] 
+# [END anthosconfig_foo_corp_pod_security_policy] 

--- a/foo-corp/namespaces/audit/namespace.yaml
+++ b/foo-corp/namespaces/audit/namespace.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_audit_namespace] 
+# [START anthosconfig_foo_corp_audit_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: audit
-# [END anthos_config_management_foo_corp_audit_namespace] 
+# [END anthosconfig_foo_corp_audit_namespace] 

--- a/foo-corp/namespaces/online/shipping-app-backend/pod-creator-rolebinding.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/pod-creator-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_shipping_app_backend_role_binding] 
+# [START anthosconfig_foo_corp_shipping_app_backend_role_binding] 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -24,4 +24,4 @@ roleRef:
   kind: ClusterRole
   name: pod-creator
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_foo_corp_shipping_app_backend_role_binding] 
+# [END anthosconfig_foo_corp_shipping_app_backend_role_binding] 

--- a/foo-corp/namespaces/online/shipping-app-backend/quota.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/quota.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_shipping_app_backend_quota] 
+# [START anthosconfig_foo_corp_shipping_app_backend_quota] 
 kind: ResourceQuota
 apiVersion: v1
 metadata:
@@ -21,4 +21,4 @@ spec:
     pods: "3"
     cpu: "1"
     memory: 1Gi
-# [END anthos_config_management_foo_corp_shipping_app_backend_quota] 
+# [END anthosconfig_foo_corp_shipping_app_backend_quota] 

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-dev/job-creator-role.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-dev/job-creator-role.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_shipping_dev_job_creator_role] 
+# [START anthosconfig_foo_corp_shipping_dev_job_creator_role] 
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,4 +21,4 @@ rules:
   resources: ["jobs"]
   verbs:
    - "*"
-# [END anthos_config_management_foo_corp_shipping_dev_job_creator_role] 
+# [END anthosconfig_foo_corp_shipping_dev_job_creator_role] 

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-dev/job-creator-rolebinding.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-dev/job-creator-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_shipping_dev_job_creators_role_binding] 
+# [START anthosconfig_foo_corp_shipping_dev_job_creators_role_binding] 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -24,4 +24,4 @@ roleRef:
   kind: Role
   name: job-creator
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_foo_corp_shipping_dev_job_creators_role_binding] 
+# [END anthosconfig_foo_corp_shipping_dev_job_creators_role_binding] 

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-dev/namespace.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-dev/namespace.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_shipping_dev_namespace] 
+# [START anthosconfig_foo_corp_shipping_dev_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: shipping-dev
-# [END anthos_config_management_foo_corp_shipping_dev_namespace] 
+# [END anthosconfig_foo_corp_shipping_dev_namespace] 

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-prod/fulfillmentcenter.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-prod/fulfillmentcenter.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_shipping_prod_fulfillment_center] 
+# [START anthosconfig_foo_corp_shipping_prod_fulfillment_center] 
 kind: FulfillmentCenter
 apiVersion: foo-corp.com/v1
 metadata:
   name: production
 spec:
   address: "100 Industry St."
-# [END anthos_config_management_foo_corp_shipping_prod_fulfillment_center] 
+# [END anthosconfig_foo_corp_shipping_prod_fulfillment_center] 

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-prod/namespace.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-prod/namespace.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_shipping_prod_namespace] 
+# [START anthosconfig_foo_corp_shipping_prod_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -20,4 +20,4 @@ metadata:
     env: prod
   annotations:
     audit: "true"
-# [END anthos_config_management_foo_corp_shipping_prod_namespace] 
+# [END anthosconfig_foo_corp_shipping_prod_namespace] 

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-staging/fulfillmentcenter.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-staging/fulfillmentcenter.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_shipping_staging_fulfillment_center] 
+# [START anthosconfig_foo_corp_shipping_staging_fulfillment_center] 
 kind: FulfillmentCenter
 apiVersion: foo-corp.com/v1
 metadata:
   name: staging
 spec:
   address: "100 Main St."
-# [END anthos_config_management_foo_corp_shipping_staging_fulfillment_center] 
+# [END anthosconfig_foo_corp_shipping_staging_fulfillment_center] 

--- a/foo-corp/namespaces/online/shipping-app-backend/shipping-staging/namespace.yaml
+++ b/foo-corp/namespaces/online/shipping-app-backend/shipping-staging/namespace.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_shipping_staging_namespace] 
+# [START anthosconfig_foo_corp_shipping_staging_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: shipping-staging
-# [END anthos_config_management_foo_corp_shipping_staging_namespace] 
+# [END anthosconfig_foo_corp_shipping_staging_namespace] 

--- a/foo-corp/namespaces/sre-rolebinding.yaml
+++ b/foo-corp/namespaces/sre-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_sre_role_binding] 
+# [START anthosconfig_foo_corp_sre_role_binding] 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -26,4 +26,4 @@ roleRef:
   kind: ClusterRole
   name: admin
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_foo_corp_sre_role_binding] 
+# [END anthosconfig_foo_corp_sre_role_binding] 

--- a/foo-corp/namespaces/sre-supported-selector.yaml
+++ b/foo-corp/namespaces/sre-supported-selector.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_sre_supported_selector]
+# [START anthosconfig_foo_corp_sre_supported_selector]
 kind: NamespaceSelector
 apiVersion: configmanagement.gke.io/v1
 metadata:
@@ -20,4 +20,4 @@ spec:
   selector:
     matchLabels:
       env: prod
-# [END anthos_config_management_foo_corp_sre_supported_selector]
+# [END anthosconfig_foo_corp_sre_supported_selector]

--- a/foo-corp/namespaces/viewers-rolebinding.yaml
+++ b/foo-corp/namespaces/viewers-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_viewers_role_binding]
+# [START anthosconfig_foo_corp_viewers_role_binding]
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -24,4 +24,4 @@ roleRef:
   kind: ClusterRole
   name: view
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_foo_corp_viewers_role_binding]
+# [END anthosconfig_foo_corp_viewers_role_binding]

--- a/foo-corp/system/repo.yaml
+++ b/foo-corp/system/repo.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_foo_corp_repo]
+# [START anthosconfig_foo_corp_repo]
 apiVersion: configmanagement.gke.io/v1
 kind: Repo
 metadata:
   name: repo
 spec:
   version: 1.0.0
-# [END anthos_config_management_foo_corp_repo]
+# [END anthosconfig_foo_corp_repo]

--- a/hello-namespace/config-root/namespaces/hello/namespace.yaml
+++ b/hello-namespace/config-root/namespaces/hello/namespace.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # creates namespace named "hello"
-# [START anthos_config_management_hello_namespace_namespace] 
+# [START anthosconfig_hello_namespace_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: hello
-# [END anthos_config_management_hello_namespace_namespace] 
+# [END anthosconfig_hello_namespace_namespace] 

--- a/hello-namespace/config-root/system/repo.yaml
+++ b/hello-namespace/config-root/system/repo.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hello_namespace_repo] 
+# [START anthosconfig_hello_namespace_repo] 
 apiVersion: configmanagement.gke.io/v1
 kind: Repo
 metadata:
   name: repo
 spec:
   version: 1.0.0
-# [END anthos_config_management_hello_namespace_repo] 
+# [END anthosconfig_hello_namespace_repo] 

--- a/hello-namespace/setup/hello-namespace/config-management.yaml
+++ b/hello-namespace/setup/hello-namespace/config-management.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hello_namespace_config_management] 
+# [START anthosconfig_hello_namespace_config_management] 
 apiVersion: configmanagement.gke.io/v1
 kind: ConfigManagement
 metadata:
@@ -24,4 +24,4 @@ spec:
     syncBranch: main
     secretType: ssh
     policyDir: "hello-namespace/config-root"
-# [END anthos_config_management_hello_namespace_config_management] 
+# [END anthosconfig_hello_namespace_config_management] 

--- a/helm-component/automated-rendering/ignore-deployment-mutation-patch.yaml
+++ b/helm-component/automated-rendering/ignore-deployment-mutation-patch.yaml
@@ -11,9 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START anthosconfig_automated_rendering_ignore_deployment_mutation_patch_deployment_any]
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: any
   annotations:
     client.lifecycle.config.k8s.io/mutation: ignore
+# [END anthosconfig_automated_rendering_ignore_deployment_mutation_patch_deployment_any]

--- a/helm-component/automated-rendering/kustomization.yaml
+++ b/helm-component/automated-rendering/kustomization.yaml
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# [START anthosconfig_helm_component_automated_rendering_kustomization_yaml]
 resources:
 - base
 
@@ -18,3 +20,4 @@ patches:
 - path: ignore-deployment-mutation-patch.yaml
   target:
     kind: Deployment
+# [END anthosconfig_helm_component_automated_rendering_kustomization_yaml]

--- a/helm-component/manual-rendering/manifests/namespace-cert-manager.yaml
+++ b/helm-component/manual-rendering/manifests/namespace-cert-manager.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_helm_component_manifests_cert_manager_namespace] 
+# [START anthosconfig_helm_component_manifests_cert_manager_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: cert-manager
-# [END anthos_config_management_helm_component_manifests_cert_manager_namespace] 
+# [END anthosconfig_helm_component_manifests_cert_manager_namespace] 

--- a/hierarchical-format/compiled/clusterrole_namespace-reader.yaml
+++ b/hierarchical-format/compiled/clusterrole_namespace-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_cluster_role_namespace_reader]
+# [START anthosconfig_hierarchical_format_compiled_cluster_role_namespace_reader]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -32,4 +32,4 @@ rules:
   - get
   - watch
   - list
-# [END anthos_config_management_hierarchical_format_compiled_cluster_role_namespace_reader]
+# [END anthosconfig_hierarchical_format_compiled_cluster_role_namespace_reader]

--- a/hierarchical-format/compiled/clusterrole_secret-admin.yaml
+++ b/hierarchical-format/compiled/clusterrole_secret-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_cluster_role_secret_admin]
+# [START anthosconfig_hierarchical_format_compiled_cluster_role_secret_admin]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -30,4 +30,4 @@ rules:
   - secrets
   verbs:
   - '*'
-# [END anthos_config_management_hierarchical_format_compiled_cluster_role_secret_admin]
+# [END anthosconfig_hierarchical_format_compiled_cluster_role_secret_admin]

--- a/hierarchical-format/compiled/clusterrole_secret-reader.yaml
+++ b/hierarchical-format/compiled/clusterrole_secret-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_cluster_role_secret_reader]
+# [START anthosconfig_hierarchical_format_compiled_cluster_role_secret_reader]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -32,4 +32,4 @@ rules:
   - get
   - watch
   - list
-# [END anthos_config_management_hierarchical_format_compiled_cluster_role_secret_reader]
+# [END anthosconfig_hierarchical_format_compiled_cluster_role_secret_reader]

--- a/hierarchical-format/compiled/clusterrolebinding_namespace-reader.yaml
+++ b/hierarchical-format/compiled/clusterrolebinding_namespace-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_cluster_role_binding_namespace_reader]
+# [START anthosconfig_hierarchical_format_compiled_cluster_role_binding_namespace_reader]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -34,4 +34,4 @@ subjects:
 - kind: ServiceAccount
   name: sa
   namespace: team-2
-# [END anthos_config_management_hierarchical_format_compiled_cluster_role_binding_namespace_reader]
+# [END anthosconfig_hierarchical_format_compiled_cluster_role_binding_namespace_reader]

--- a/hierarchical-format/compiled/customresourcedefinition_crontabs.stable.example.com.yaml
+++ b/hierarchical-format/compiled/customresourcedefinition_crontabs.stable.example.com.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_custom_resource_definition_crontabs]
+# [START anthosconfig_hierarchical_format_compiled_custom_resource_definition_crontabs]
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -49,4 +49,4 @@ spec:
         type: object
     served: true
     storage: true
-# [END anthos_config_management_hierarchical_format_compiled_custom_resource_definition_crontabs]
+# [END anthosconfig_hierarchical_format_compiled_custom_resource_definition_crontabs]

--- a/hierarchical-format/compiled/namespace_team-1.yaml
+++ b/hierarchical-format/compiled/namespace_team-1.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_namespace_team_1]
+# [START anthosconfig_hierarchical_format_compiled_namespace_team_1]
 ---
 apiVersion: v1
 kind: Namespace
@@ -25,4 +25,4 @@ metadata:
     configsync.gke.io/declared-version: v1
     team-1.tree.hnc.x-k8s.io/depth: "0"
   name: team-1
-# [END anthos_config_management_hierarchical_format_compiled_namespace_team_1]
+# [END anthosconfig_hierarchical_format_compiled_namespace_team_1]

--- a/hierarchical-format/compiled/namespace_team-2.yaml
+++ b/hierarchical-format/compiled/namespace_team-2.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_namespace_team_2]
+# [START anthosconfig_hierarchical_format_compiled_namespace_team_2]
 ---
 apiVersion: v1
 kind: Namespace
@@ -25,4 +25,4 @@ metadata:
     configsync.gke.io/declared-version: v1
     team-2.tree.hnc.x-k8s.io/depth: "0"
   name: team-2
-# [END anthos_config_management_hierarchical_format_compiled_namespace_team_2]
+# [END anthosconfig_hierarchical_format_compiled_namespace_team_2]

--- a/hierarchical-format/compiled/team-1/crontab_my-new-cron-object.yaml
+++ b/hierarchical-format/compiled/team-1/crontab_my-new-cron-object.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_1_crontab] 
+# [START anthosconfig_hierarchical_format_compiled_team_1_crontab] 
 ---
 apiVersion: stable.example.com/v1
 kind: CronTab
@@ -27,4 +27,4 @@ metadata:
 spec:
   cronSpec: '* * * * */5'
   image: my-awesome-cron-image
-# [END anthos_config_management_hierarchical_format_compiled_team_1_crontab] 
+# [END anthosconfig_hierarchical_format_compiled_team_1_crontab] 

--- a/hierarchical-format/compiled/team-1/limitrange_limits.yaml
+++ b/hierarchical-format/compiled/team-1/limitrange_limits.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_1_limit_range] 
+# [START anthosconfig_hierarchical_format_compiled_team_1_limit_range] 
 ---
 apiVersion: v1
 kind: LimitRange
@@ -33,4 +33,4 @@ spec:
   - max:
       storage: 2Gi
     type: PersistentVolumeClaim
-# [END anthos_config_management_hierarchical_format_compiled_team_1_limit_range] 
+# [END anthosconfig_hierarchical_format_compiled_team_1_limit_range] 

--- a/hierarchical-format/compiled/team-1/networkpolicy_default-deny-egress.yaml
+++ b/hierarchical-format/compiled/team-1/networkpolicy_default-deny-egress.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_1_network_policy] 
+# [START anthosconfig_hierarchical_format_compiled_team_1_network_policy] 
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -28,4 +28,4 @@ spec:
   podSelector: {}
   policyTypes:
   - Egress
-# [END anthos_config_management_hierarchical_format_compiled_team_1_network_policy] 
+# [END anthosconfig_hierarchical_format_compiled_team_1_network_policy] 

--- a/hierarchical-format/compiled/team-1/resourcequota_pvc.yaml
+++ b/hierarchical-format/compiled/team-1/resourcequota_pvc.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_1_resource_quota] 
+# [START anthosconfig_hierarchical_format_compiled_team_1_resource_quota] 
 ---
 apiVersion: v1
 kind: ResourceQuota
@@ -27,4 +27,4 @@ metadata:
 spec:
   hard:
     persistentvolumeclaims: "3"
-# [END anthos_config_management_hierarchical_format_compiled_team_1_resource_quota] 
+# [END anthosconfig_hierarchical_format_compiled_team_1_resource_quota] 

--- a/hierarchical-format/compiled/team-1/rolebinding_secret-reader.yaml
+++ b/hierarchical-format/compiled/team-1/rolebinding_secret-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_1_role_binding_secret_reader] 
+# [START anthosconfig_hierarchical_format_compiled_team_1_role_binding_secret_reader] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -32,4 +32,4 @@ subjects:
 - kind: ServiceAccount
   name: sa
   namespace: team-1
-# [END anthos_config_management_hierarchical_format_compiled_team_1_role_binding_secret_reader] 
+# [END anthosconfig_hierarchical_format_compiled_team_1_role_binding_secret_reader] 

--- a/hierarchical-format/compiled/team-1/serviceaccount_sa.yaml
+++ b/hierarchical-format/compiled/team-1/serviceaccount_sa.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_1_service_account] 
+# [START anthosconfig_hierarchical_format_compiled_team_1_service_account] 
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -24,4 +24,4 @@ metadata:
     configsync.gke.io/declared-version: v1
   name: sa
   namespace: team-1
-# [END anthos_config_management_hierarchical_format_compiled_team_1_service_account] 
+# [END anthosconfig_hierarchical_format_compiled_team_1_service_account] 

--- a/hierarchical-format/compiled/team-2/crontab_my-new-cron-object.yaml
+++ b/hierarchical-format/compiled/team-2/crontab_my-new-cron-object.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_2_crontab] 
+# [START anthosconfig_hierarchical_format_compiled_team_2_crontab] 
 ---
 apiVersion: stable.example.com/v1
 kind: CronTab
@@ -27,4 +27,4 @@ metadata:
 spec:
   cronSpec: '* * * * */5'
   image: my-awesome-cron-image
-# [END anthos_config_management_hierarchical_format_compiled_team_2_crontab] 
+# [END anthosconfig_hierarchical_format_compiled_team_2_crontab] 

--- a/hierarchical-format/compiled/team-2/limitrange_limits.yaml
+++ b/hierarchical-format/compiled/team-2/limitrange_limits.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_2_limit_range] 
+# [START anthosconfig_hierarchical_format_compiled_team_2_limit_range] 
 ---
 apiVersion: v1
 kind: LimitRange
@@ -33,4 +33,4 @@ spec:
   - max:
       storage: 2Gi
     type: PersistentVolumeClaim
-# [END anthos_config_management_hierarchical_format_compiled_team_2_limit_range] 
+# [END anthosconfig_hierarchical_format_compiled_team_2_limit_range] 

--- a/hierarchical-format/compiled/team-2/networkpolicy_default-deny-all.yaml
+++ b/hierarchical-format/compiled/team-2/networkpolicy_default-deny-all.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_2_network_policy] 
+# [START anthosconfig_hierarchical_format_compiled_team_2_network_policy] 
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -29,4 +29,4 @@ spec:
   policyTypes:
   - Ingress
   - Egress
-# [END anthos_config_management_hierarchical_format_compiled_team_2_network_policy] 
+# [END anthosconfig_hierarchical_format_compiled_team_2_network_policy] 

--- a/hierarchical-format/compiled/team-2/resourcequota_pvc.yaml
+++ b/hierarchical-format/compiled/team-2/resourcequota_pvc.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_2_resource_quota] 
+# [START anthosconfig_hierarchical_format_compiled_team_2_resource_quota] 
 ---
 apiVersion: v1
 kind: ResourceQuota
@@ -27,4 +27,4 @@ metadata:
 spec:
   hard:
     persistentvolumeclaims: "6"
-# [END anthos_config_management_hierarchical_format_compiled_team_2_resource_quota] 
+# [END anthosconfig_hierarchical_format_compiled_team_2_resource_quota] 

--- a/hierarchical-format/compiled/team-2/rolebinding_secret-admin.yaml
+++ b/hierarchical-format/compiled/team-2/rolebinding_secret-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_2_role_binding_secret_admin] 
+# [START anthosconfig_hierarchical_format_compiled_team_2_role_binding_secret_admin] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -32,4 +32,4 @@ subjects:
 - kind: ServiceAccount
   name: sa
   namespace: team-2
-# [END anthos_config_management_hierarchical_format_compiled_team_2_role_binding_secret_admin] 
+# [END anthosconfig_hierarchical_format_compiled_team_2_role_binding_secret_admin] 

--- a/hierarchical-format/compiled/team-2/serviceaccount_sa.yaml
+++ b/hierarchical-format/compiled/team-2/serviceaccount_sa.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_compiled_team_2_service_account]
+# [START anthosconfig_hierarchical_format_compiled_team_2_service_account]
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -24,4 +24,4 @@ metadata:
     configsync.gke.io/declared-version: v1
   name: sa
   namespace: team-2
-# [END anthos_config_management_hierarchical_format_compiled_team_2_service_account]
+# [END anthosconfig_hierarchical_format_compiled_team_2_service_account]

--- a/hierarchical-format/config/cluster/clusterrole-namespace-reader.yaml
+++ b/hierarchical-format/config/cluster/clusterrole-namespace-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_cluster_role_namespace_reader]
+# [START anthosconfig_hierarchical_format_config_cluster_role_namespace_reader]
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,4 +20,4 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "watch", "list"]
-# [END anthos_config_management_hierarchical_format_config_cluster_role_namespace_reader]
+# [END anthosconfig_hierarchical_format_config_cluster_role_namespace_reader]

--- a/hierarchical-format/config/cluster/clusterrole-secret-admin.yaml
+++ b/hierarchical-format/config/cluster/clusterrole-secret-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_cluster_role_secret_admin]
+# [START anthosconfig_hierarchical_format_config_cluster_role_secret_admin]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,4 +24,4 @@ rules:
   # objects is "secrets"
   resources: ["secrets"]
   verbs: ["*"]
-# [END anthos_config_management_hierarchical_format_config_cluster_role_secret_admin]
+# [END anthosconfig_hierarchical_format_config_cluster_role_secret_admin]

--- a/hierarchical-format/config/cluster/clusterrole-secret-reader.yaml
+++ b/hierarchical-format/config/cluster/clusterrole-secret-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_cluster_role_secret_reader]
+# [START anthosconfig_hierarchical_format_config_cluster_role_secret_reader]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -24,4 +24,4 @@ rules:
   # objects is "secrets"
   resources: ["secrets"]
   verbs: ["get", "watch", "list"]
-# [END anthos_config_management_hierarchical_format_config_cluster_role_secret_reader]
+# [END anthosconfig_hierarchical_format_config_cluster_role_secret_reader]

--- a/hierarchical-format/config/cluster/clusterrolebinding-namespace-reader.yaml
+++ b/hierarchical-format/config/cluster/clusterrolebinding-namespace-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_cluster_role_binding_namespace_reader]
+# [START anthosconfig_hierarchical_format_config_cluster_role_binding_namespace_reader]
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -27,4 +27,4 @@ subjects:
 - kind: ServiceAccount
   name: sa
   namespace: team-2
-# [END anthos_config_management_hierarchical_format_config_cluster_role_binding_namespace_reader]
+# [END anthosconfig_hierarchical_format_config_cluster_role_binding_namespace_reader]

--- a/hierarchical-format/config/cluster/crontab-crd.yaml
+++ b/hierarchical-format/config/cluster/crontab-crd.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_custom_resource_definition_crontabs]
+# [START anthosconfig_hierarchical_format_config_custom_resource_definition_crontabs]
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -52,4 +52,4 @@ spec:
     # shortNames allow shorter string to match your resource on the CLI
     shortNames:
     - ct
-# [END anthos_config_management_hierarchical_format_config_custom_resource_definition_crontabs]
+# [END anthosconfig_hierarchical_format_config_custom_resource_definition_crontabs]

--- a/hierarchical-format/config/namespaces/limit-range.yaml
+++ b/hierarchical-format/config/namespaces/limit-range.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # LimitRange Reference: https://kubernetes.io/docs/concepts/policy/limit-range/
-# [START anthos_config_management_hierarchical_format_config_namespaces_limit_range]
+# [START anthosconfig_hierarchical_format_config_namespaces_limit_range]
 apiVersion: v1
 kind: LimitRange
 metadata:
@@ -26,4 +26,4 @@ spec:
   - type: PersistentVolumeClaim
     max:
       storage: 2Gi
-# [END anthos_config_management_hierarchical_format_config_namespaces_limit_range]
+# [END anthosconfig_hierarchical_format_config_namespaces_limit_range]

--- a/hierarchical-format/config/namespaces/team-1/crontab.yaml
+++ b/hierarchical-format/config/namespaces/team-1/crontab.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_1_crontab]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_1_crontab]
 apiVersion: "stable.example.com/v1"
 kind: CronTab
 metadata:
@@ -19,4 +19,4 @@ metadata:
 spec:
   cronSpec: "* * * * */5"
   image: my-awesome-cron-image
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_1_crontab]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_1_crontab]

--- a/hierarchical-format/config/namespaces/team-1/namespace.yaml
+++ b/hierarchical-format/config/namespaces/team-1/namespace.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_1_namespace]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_1_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: team-1
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_1_namespace]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_1_namespace]

--- a/hierarchical-format/config/namespaces/team-1/network-policy-default-deny-egress.yaml
+++ b/hierarchical-format/config/namespaces/team-1/network-policy-default-deny-egress.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_1_network_policy]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_1_network_policy]
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -21,4 +21,4 @@ spec:
   podSelector: {}
   policyTypes:
   - Egress
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_1_network_policy]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_1_network_policy]

--- a/hierarchical-format/config/namespaces/team-1/resource-quota-pvc.yaml
+++ b/hierarchical-format/config/namespaces/team-1/resource-quota-pvc.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_1_resource_quota]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_1_resource_quota]
 # ResourceQuota Reference: https://kubernetes.io/docs/concepts/policy/resource-quotas/
 kind: ResourceQuota
 apiVersion: v1
@@ -20,4 +20,4 @@ metadata:
 spec:
   hard:
     persistentvolumeclaims: "3"
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_1_resource_quota]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_1_resource_quota]

--- a/hierarchical-format/config/namespaces/team-1/rolebinding-secret-reader.yaml
+++ b/hierarchical-format/config/namespaces/team-1/rolebinding-secret-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_1_role_binding_secret_reader]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_1_role_binding_secret_reader]
 apiVersion: rbac.authorization.k8s.io/v1
 # This role binding allows "jane" to read pods in the "default" namespace.
 # You need to already have a Role named "pod-reader" in that namespace.
@@ -28,4 +28,4 @@ roleRef:
   kind: ClusterRole
   name: secret-reader
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_1_role_binding_secret_reader]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_1_role_binding_secret_reader]

--- a/hierarchical-format/config/namespaces/team-1/sa.yaml
+++ b/hierarchical-format/config/namespaces/team-1/sa.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_1_service_account]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_1_service_account]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: sa
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_1_service_account]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_1_service_account]

--- a/hierarchical-format/config/namespaces/team-2/crontab.yaml
+++ b/hierarchical-format/config/namespaces/team-2/crontab.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_2_crontab]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_2_crontab]
 apiVersion: "stable.example.com/v1"
 kind: CronTab
 metadata:
@@ -19,4 +19,4 @@ metadata:
 spec:
   cronSpec: "* * * * */5"
   image: my-awesome-cron-image
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_2_crontab]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_2_crontab]

--- a/hierarchical-format/config/namespaces/team-2/namespace.yaml
+++ b/hierarchical-format/config/namespaces/team-2/namespace.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_2_namespace]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_2_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: team-2
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_2_namespace]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_2_namespace]

--- a/hierarchical-format/config/namespaces/team-2/network-policy-default-deny-all.yaml
+++ b/hierarchical-format/config/namespaces/team-2/network-policy-default-deny-all.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_2_network_policy]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_2_network_policy]
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -22,4 +22,4 @@ spec:
   policyTypes:
   - Ingress
   - Egress
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_2_network_policy]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_2_network_policy]

--- a/hierarchical-format/config/namespaces/team-2/resource-quota-pvc.yaml
+++ b/hierarchical-format/config/namespaces/team-2/resource-quota-pvc.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_2_resource_quota]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_2_resource_quota]
 # ResourceQuota Reference: https://kubernetes.io/docs/concepts/policy/resource-quotas/
 kind: ResourceQuota
 apiVersion: v1
@@ -20,4 +20,4 @@ metadata:
 spec:
   hard:
     persistentvolumeclaims: "6"
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_2_resource_quota]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_2_resource_quota]

--- a/hierarchical-format/config/namespaces/team-2/rolebinding-secret-admin.yaml
+++ b/hierarchical-format/config/namespaces/team-2/rolebinding-secret-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_2_role_binding_secret_admin]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_2_role_binding_secret_admin]
 apiVersion: rbac.authorization.k8s.io/v1
 # This role binding allows "jane" to read pods in the "default" namespace.
 # You need to already have a Role named "pod-reader" in that namespace.
@@ -28,4 +28,4 @@ roleRef:
   kind: ClusterRole
   name: secret-admin
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_2_role_binding_secret_admin]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_2_role_binding_secret_admin]

--- a/hierarchical-format/config/namespaces/team-2/sa.yaml
+++ b/hierarchical-format/config/namespaces/team-2/sa.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_hierarchical_format_config_namespaces_team_2_service_account]
+# [START anthosconfig_hierarchical_format_config_namespaces_team_2_service_account]
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: sa
-# [END anthos_config_management_hierarchical_format_config_namespaces_team_2_service_account]
+# [END anthosconfig_hierarchical_format_config_namespaces_team_2_service_account]

--- a/hierarchical-format/config/system/repo.yaml
+++ b/hierarchical-format/config/system/repo.yaml
@@ -13,11 +13,11 @@
 # limitations under the License.
 # For the mono-repo mode, declaring a Repo resource under system/ directory is required.
 # For the multi-repo mode, declaring a Repo resource under system/ directory is optional.
-# [START anthos_config_management_hierarchical_format_config_repo]
+# [START anthosconfig_hierarchical_format_config_repo]
 apiVersion: configmanagement.gke.io/v1
 kind: Repo
 metadata:
   name: repo
 spec:
   version: 1.0.0
-# [END anthos_config_management_hierarchical_format_config_repo]
+# [END anthosconfig_hierarchical_format_config_repo]

--- a/kustomize-pipeline/build/cloudbuild.yaml
+++ b/kustomize-pipeline/build/cloudbuild.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_kustomize_pipeline_cloudbuild]
+# [START anthosconfig_kustomize_pipeline_cloudbuild]
 steps:
 - name: 'gcr.io/google-samples/cloudbuild-kustomize:latest'
   id: kustomize-render
@@ -50,4 +50,4 @@ availableSecrets:
   secretManager:
   - versionName: projects/${PROJECT_ID}/secrets/github-token/versions/1 
     env: 'GITHUB_TOKEN'
-# [END anthos_config_management_kustomize_pipeline_cloudbuild]
+# [END anthosconfig_kustomize_pipeline_cloudbuild]

--- a/kustomize-pipeline/config-management.yaml
+++ b/kustomize-pipeline/config-management.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_kustomize_pipeline_config_management]
+# [START anthosconfig_kustomize_pipeline_config_management]
 # config-management.yaml
 apiVersion: configmanagement.gke.io/v1
 kind: ConfigManagement
@@ -27,4 +27,4 @@ spec:
     policyDir: deploy-config/
     syncBranch: main
   sourceFormat: unstructured
-# [END anthos_config_management_kustomize_pipeline_config_management]
+# [END anthosconfig_kustomize_pipeline_config_management]

--- a/kustomize-pipeline/source-config/bases/roles/clusterrole-namespace-reader.yaml
+++ b/kustomize-pipeline/source-config/bases/roles/clusterrole-namespace-reader.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_kustomize_pipeline_cluster_role_namespace_reader]
+# [START anthosconfig_kustomize_pipeline_cluster_role_namespace_reader]
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -20,4 +20,4 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "watch", "list"]
-# [END anthos_config_management_kustomize_pipeline_cluster_role_namespace_reader]
+# [END anthosconfig_kustomize_pipeline_cluster_role_namespace_reader]

--- a/kustomize-pipeline/source-config/bases/roles/kustomization.yaml
+++ b/kustomize-pipeline/source-config/bases/roles/kustomization.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_kustomize_pipeline_bases_roles_kustomization]
+# [START anthosconfig_kustomize_pipeline_bases_roles_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - clusterrole-namespace-reader.yaml
-# [END anthos_config_management_kustomize_pipeline_bases_roles_kustomization]
+# [END anthosconfig_kustomize_pipeline_bases_roles_kustomization]

--- a/kustomize-pipeline/source-config/kustomization.yaml
+++ b/kustomize-pipeline/source-config/kustomization.yaml
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_kustomize_pipeline_bases_kustomization]
+# [START anthosconfig_kustomize_pipeline_bases_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - bases/roles/
 namePrefix: sample-
-# [END anthos_config_management_kustomize_pipeline_bases_kustomization]
+# [END anthosconfig_kustomize_pipeline_bases_kustomization]

--- a/locality-specific-policy/config-root/cluster/clusterrole.auditor.yaml
+++ b/locality-specific-policy/config-root/cluster/clusterrole.auditor.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_cluster_role_auditor]
+# [START anthosconfig_locality_specific_policy_cluster_role_auditor]
 # will only be applied to clusters with belgium location label
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,4 +23,4 @@ rules:
 - apiGroups: [""] # core API group
   resources: ["namespaces"]
   verbs: ["get", "watch", "list"]
-# [END anthos_config_management_locality_specific_policy_cluster_role_auditor]
+# [END anthosconfig_locality_specific_policy_cluster_role_auditor]

--- a/locality-specific-policy/config-root/cluster/clusterrolebinding.auditors.yaml
+++ b/locality-specific-policy/config-root/cluster/clusterrolebinding.auditors.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_cluster_role_binding_auditors]
+# [START anthosconfig_locality_specific_policy_cluster_role_binding_auditors]
 # will only be applied to clusters with belgium location label
 kind: ClusterRoleBinding 
 apiVersion: rbac.authorization.k8s.io/v1
@@ -27,4 +27,4 @@ roleRef:
   kind: ClusterRole
   name: auditor
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_locality_specific_policy_cluster_role_binding_auditors]
+# [END anthosconfig_locality_specific_policy_cluster_role_binding_auditors]

--- a/locality-specific-policy/config-root/clusterregistry/cluster.belgium-2.yaml
+++ b/locality-specific-policy/config-root/clusterregistry/cluster.belgium-2.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_cluster_belgium_2]
+# [START anthosconfig_locality_specific_policy_cluster_belgium_2]
 # applies location and environment labels to cluster
 kind: Cluster
 apiVersion: clusterregistry.k8s.io/v1alpha1
@@ -20,4 +20,4 @@ metadata:
   labels:
     environment: dev
     location: belgium
-# [END anthos_config_management_locality_specific_policy_cluster_belgium_2]
+# [END anthosconfig_locality_specific_policy_cluster_belgium_2]

--- a/locality-specific-policy/config-root/clusterregistry/cluster.belgium.yaml
+++ b/locality-specific-policy/config-root/clusterregistry/cluster.belgium.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_cluster_belgium]
+# [START anthosconfig_locality_specific_policy_cluster_belgium]
 # applies location and environment labels to cluster
 kind: Cluster
 apiVersion: clusterregistry.k8s.io/v1alpha1
@@ -20,4 +20,4 @@ metadata:
   labels:
     environment: prod
     location: belgium
-# [END anthos_config_management_locality_specific_policy_cluster_belgium]
+# [END anthosconfig_locality_specific_policy_cluster_belgium]

--- a/locality-specific-policy/config-root/clusterregistry/cluster.iowa.yaml
+++ b/locality-specific-policy/config-root/clusterregistry/cluster.iowa.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_cluster_iowa]
+# [START anthosconfig_locality_specific_policy_cluster_iowa]
 # applies location and environment labels to cluster
 kind: Cluster
 apiVersion: clusterregistry.k8s.io/v1alpha1
@@ -20,4 +20,4 @@ metadata:
   labels:
     environment: prod
     location: usa
-# [END anthos_config_management_locality_specific_policy_cluster_iowa]
+# [END anthosconfig_locality_specific_policy_cluster_iowa]

--- a/locality-specific-policy/config-root/clusterregistry/cluster.taiwan.yaml
+++ b/locality-specific-policy/config-root/clusterregistry/cluster.taiwan.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_cluster_taiwan]
+# [START anthosconfig_locality_specific_policy_cluster_taiwan]
 # applies location and environment labels to cluster
 kind: Cluster
 apiVersion: clusterregistry.k8s.io/v1alpha1
@@ -20,4 +20,4 @@ metadata:
   labels:
     environment: prod
     location: taiwan
-# [END anthos_config_management_locality_specific_policy_cluster_taiwan]
+# [END anthosconfig_locality_specific_policy_cluster_taiwan]

--- a/locality-specific-policy/config-root/clusterregistry/clusterselector.select-env-prod.yaml
+++ b/locality-specific-policy/config-root/clusterregistry/clusterselector.select-env-prod.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_cluster_selector_env_prod]
+# [START anthosconfig_locality_specific_policy_cluster_selector_env_prod]
 # selects clusters with prod environment label
 kind: ClusterSelector
 apiVersion: configmanagement.gke.io/v1
@@ -21,4 +21,4 @@ spec:
   selector:
     matchLabels:
       environment: prod
-# [END anthos_config_management_locality_specific_policy_cluster_selector_env_prod]
+# [END anthosconfig_locality_specific_policy_cluster_selector_env_prod]

--- a/locality-specific-policy/config-root/clusterregistry/clusterselector.select-location-belgium.yaml
+++ b/locality-specific-policy/config-root/clusterregistry/clusterselector.select-location-belgium.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_cluster_selector_location_belgium]
+# [START anthosconfig_locality_specific_policy_cluster_selector_location_belgium]
 # selects clusters with belgium location label
 kind: ClusterSelector
 apiVersion: configmanagement.gke.io/v1
@@ -21,4 +21,4 @@ spec:
   selector:
     matchLabels:
       location: belgium
-# [END anthos_config_management_locality_specific_policy_cluster_selector_location_belgium]
+# [END anthosconfig_locality_specific_policy_cluster_selector_location_belgium]

--- a/locality-specific-policy/config-root/system/repo.yaml
+++ b/locality-specific-policy/config-root/system/repo.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_repo]
+# [START anthosconfig_locality_specific_policy_repo]
 apiVersion: configmanagement.gke.io/v1
 kind: Repo
 metadata:
   name: repo
 spec:
   version: 1.0.0
-# [END anthos_config_management_locality_specific_policy_repo]
+# [END anthosconfig_locality_specific_policy_repo]

--- a/locality-specific-policy/setup/belgium-2.config-management.yaml
+++ b/locality-specific-policy/setup/belgium-2.config-management.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_setup_config_management_belgium_2]
+# [START anthosconfig_locality_specific_policy_setup_config_management_belgium_2]
 apiVersion: configmanagement.gke.io/v1
 kind: ConfigManagement
 metadata:
@@ -24,4 +24,4 @@ spec:
     syncBranch: 1.0.0
     secretType: ssh
     policyDir: "locality-specific-policy/config-root"
-# [END anthos_config_management_locality_specific_policy_setup_config_management_belgium_2]
+# [END anthosconfig_locality_specific_policy_setup_config_management_belgium_2]

--- a/locality-specific-policy/setup/belgium.config-management.yaml
+++ b/locality-specific-policy/setup/belgium.config-management.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_setup_config_management_belgium]
+# [START anthosconfig_locality_specific_policy_setup_config_management_belgium]
 apiVersion: configmanagement.gke.io/v1
 kind: ConfigManagement
 metadata:
@@ -24,4 +24,4 @@ spec:
     syncBranch: 1.0.0
     secretType: ssh
     policyDir: "docs/locality-specific-policy/"
-# [END anthos_config_management_locality_specific_policy_setup_config_management_belgium]
+# [END anthosconfig_locality_specific_policy_setup_config_management_belgium]

--- a/locality-specific-policy/setup/iowa.config-management.yaml
+++ b/locality-specific-policy/setup/iowa.config-management.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_setup_config_management_iowa]
+# [START anthosconfig_locality_specific_policy_setup_config_management_iowa]
 apiVersion: configmanagement.gke.io/v1
 kind: ConfigManagement
 metadata:
@@ -24,4 +24,4 @@ spec:
     syncBranch: 1.0.0
     secretType: ssh
     policyDir: "locality-specific-policy/config-root"
-# [END anthos_config_management_locality_specific_policy_setup_config_management_iowa]
+# [END anthosconfig_locality_specific_policy_setup_config_management_iowa]

--- a/locality-specific-policy/setup/taiwan.config-management.yaml
+++ b/locality-specific-policy/setup/taiwan.config-management.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_locality_specific_policy_setup_config_management_taiwan]
+# [START anthosconfig_locality_specific_policy_setup_config_management_taiwan]
 apiVersion: configmanagement.gke.io/v1
 kind: ConfigManagement
 metadata:
@@ -24,4 +24,4 @@ spec:
     syncBranch: 1.0.0
     secretType: ssh
     policyDir: "locality-specific-policy/config-root"
-# [END anthos_config_management_locality_specific_policy_setup_config_management_taiwan]
+# [END anthosconfig_locality_specific_policy_setup_config_management_taiwan]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/all-namespaces/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/all-namespaces/kustomization.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_all_namespaces_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_all_namespaces_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - resource-quota.yaml
 commonLabels:
   owner: platform-team
-# [END anthos_config_management_multi_cluster_access_and_quota_src_all_namespaces_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_all_namespaces_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/all-namespaces/resource-quota.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/all-namespaces/resource-quota.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_all_namespaces_resource_quota]
+# [START anthosconfig_multi_cluster_access_and_quota_src_all_namespaces_resource_quota]
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -21,4 +21,4 @@ spec:
     cpu: "100"
     memory: 10Gi
     pods: "10"
-# [END anthos_config_management_multi_cluster_access_and_quota_src_all_namespaces_resource_quota]
+# [END anthosconfig_multi_cluster_access_and_quota_src_all_namespaces_resource_quota]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/kustomization.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - namespaces.yaml
 commonLabels:
   owner: platform-team
-# [END anthos_config_management_multi_cluster_access_and_quota_src_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces.yaml
@@ -11,23 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_tenant_a_namespace]
+# [START anthosconfig_multi_cluster_access_and_quota_src_tenant_a_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: tenant-a
-# [END anthos_config_management_multi_cluster_access_and_quota_src_tenant_a_namespace]
+# [END anthosconfig_multi_cluster_access_and_quota_src_tenant_a_namespace]
 ---
-# [START anthos_config_management_multi_cluster_access_and_quota_src_tenant_b_namespace]
+# [START anthosconfig_multi_cluster_access_and_quota_src_tenant_b_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: tenant-b
-# [END anthos_config_management_multi_cluster_access_and_quota_src_tenant_b_namespace]
+# [END anthosconfig_multi_cluster_access_and_quota_src_tenant_b_namespace]
 ---
-# [START anthos_config_management_multi_cluster_access_and_quota_src_tenant_c_namespace]
+# [START anthosconfig_multi_cluster_access_and_quota_src_tenant_c_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: tenant-c
-# [END anthos_config_management_multi_cluster_access_and_quota_src_tenant_c_namespace]
+# [END anthosconfig_multi_cluster_access_and_quota_src_tenant_c_namespace]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-a/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-a/kustomization.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_tenant_a_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_tenant_a_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - rbac.yaml
 commonLabels:
   owner: platform-team
-# [END anthos_config_management_multi_cluster_access_and_quota_src_tenant_a_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_tenant_a_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-a/rbac.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-a/rbac.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_tenant_a_role_binding]
+# [START anthosconfig_multi_cluster_access_and_quota_src_tenant_a_role_binding]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -27,4 +27,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-2
-# [END anthos_config_management_multi_cluster_access_and_quota_src_tenant_a_role_binding]
+# [END anthosconfig_multi_cluster_access_and_quota_src_tenant_a_role_binding]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-b/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-b/kustomization.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_tenant_b_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_tenant_b_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - rbac.yaml
 commonLabels:
   owner: platform-team
-# [END anthos_config_management_multi_cluster_access_and_quota_src_tenant_b_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_tenant_b_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-b/rbac.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-b/rbac.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_tenant_b_role_binding]
+# [START anthosconfig_multi_cluster_access_and_quota_src_tenant_b_role_binding]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -27,4 +27,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-12
-# [END anthos_config_management_multi_cluster_access_and_quota_src_tenant_b_role_binding]
+# [END anthosconfig_multi_cluster_access_and_quota_src_tenant_b_role_binding]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-c/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-c/kustomization.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_tenant_c_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_tenant_c_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - rbac.yaml
 commonLabels:
   owner: platform-team
-# [END anthos_config_management_multi_cluster_access_and_quota_src_tenant_c_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_tenant_c_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-c/rbac.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/all-clusters/namespaces/tenant-c/rbac.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_tenant_c_role_binding]
+# [START anthosconfig_multi_cluster_access_and_quota_src_tenant_c_role_binding]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -27,4 +27,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-22
-# [END anthos_config_management_multi_cluster_access_and_quota_src_tenant_c_role_binding]
+# [END anthosconfig_multi_cluster_access_and_quota_src_tenant_c_role_binding]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/kustomization.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_cluster_east_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../all-clusters/
 commonLabels:
   cluster: cluster-east
-# [END anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_cluster_east_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/namespaces/tenant-a/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/namespaces/tenant-a/kustomization.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_tenant_a_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_cluster_east_tenant_a_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -22,4 +22,4 @@ patchesStrategicMerge:
 commonLabels:
   cluster: cluster-east
 namespace: tenant-a
-# [END anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_tenant_a_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_cluster_east_tenant_a_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/namespaces/tenant-a/resource-quota.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/namespaces/tenant-a/resource-quota.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_tenant_a_resource_quota]
+# [START anthosconfig_multi_cluster_access_and_quota_src_cluster_east_tenant_a_resource_quota]
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -21,4 +21,4 @@ spec:
     cpu: "1000"
     memory: 100Gi
     pods: "100"
-# [END anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_tenant_a_resource_quota]
+# [END anthosconfig_multi_cluster_access_and_quota_src_cluster_east_tenant_a_resource_quota]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/namespaces/tenant-b/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/namespaces/tenant-b/kustomization.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_tenant_b_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_cluster_east_tenant_b_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -20,4 +20,4 @@ resources:
 commonLabels:
   cluster: cluster-east
 namespace: tenant-b
-# [END anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_tenant_b_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_cluster_east_tenant_b_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/namespaces/tenant-c/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-east/namespaces/tenant-c/kustomization.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_tenant_c_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_cluster_east_tenant_c_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -20,4 +20,4 @@ resources:
 commonLabels:
   cluster: cluster-east
 namespace: tenant-c
-# [END anthos_config_management_multi_cluster_access_and_quota_src_cluster_east_tenant_c_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_cluster_east_tenant_c_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-west/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-west/kustomization.yaml
@@ -11,11 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_cluster_west_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_cluster_west_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../all-clusters/
 commonLabels:
   cluster: cluster-west
-# [END anthos_config_management_multi_cluster_access_and_quota_src_cluster_west_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_cluster_west_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-west/namespaces/tenant-a/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-west/namespaces/tenant-a/kustomization.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_cluster_west_tenant_a_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_cluster_west_tenant_a_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -20,4 +20,4 @@ resources:
 commonLabels:
   cluster: cluster-west
 namespace: tenant-a
-# [END anthos_config_management_multi_cluster_access_and_quota_src_cluster_west_tenant_a_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_cluster_west_tenant_a_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-west/namespaces/tenant-b/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-west/namespaces/tenant-b/kustomization.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_cluster_west_tenant_b_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_cluster_west_tenant_b_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -20,4 +20,4 @@ resources:
 commonLabels:
   cluster: cluster-west
 namespace: tenant-b
-# [END anthos_config_management_multi_cluster_access_and_quota_src_cluster_west_tenant_b_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_cluster_west_tenant_b_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-west/namespaces/tenant-c/kustomization.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync-src/clusters/cluster-west/namespaces/tenant-c/kustomization.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_src_cluster_west_tenant_c_kustomization]
+# [START anthosconfig_multi_cluster_access_and_quota_src_cluster_west_tenant_c_kustomization]
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -20,4 +20,4 @@ resources:
 commonLabels:
   cluster: cluster-west
 namespace: tenant-c
-# [END anthos_config_management_multi_cluster_access_and_quota_src_cluster_west_tenant_c_kustomization]
+# [END anthosconfig_multi_cluster_access_and_quota_src_cluster_west_tenant_c_kustomization]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-a/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-a/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_a_role_binding]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_a_role_binding]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -31,4 +31,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-2
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_a_role_binding]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_a_role_binding]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-a/v1_resourcequota_hard-limit.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-a/v1_resourcequota_hard-limit.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_a_resource_quota]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_a_resource_quota]
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -25,4 +25,4 @@ spec:
     cpu: "1000"
     memory: 100Gi
     pods: "100"
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_a_resource_quota]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_a_resource_quota]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-b/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-b/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_b_role_binding]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_b_role_binding]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -31,4 +31,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-12
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_b_role_binding]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_b_role_binding]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-b/v1_resourcequota_hard-limit.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-b/v1_resourcequota_hard-limit.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_b_resource_quota]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_b_resource_quota]
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -25,4 +25,4 @@ spec:
     cpu: "100"
     memory: 10Gi
     pods: "10"
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_b_resource_quota]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_b_resource_quota]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-c/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-c/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_c_role_binding]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_c_role_binding]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -31,4 +31,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-22
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_c_role_binding]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_c_role_binding]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-c/v1_resourcequota_hard-limit.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/namespaces/tenant-c/v1_resourcequota_hard-limit.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_c_resource_quota]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_c_resource_quota]
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -25,4 +25,4 @@ spec:
     cpu: "100"
     memory: 10Gi
     pods: "10"
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_c_resource_quota]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_c_resource_quota]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/v1_namespace_tenant-a.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/v1_namespace_tenant-a.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_a_namespace]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_a_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -19,4 +19,4 @@ metadata:
     cluster: cluster-east
     owner: platform-team
   name: tenant-a
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_a_namespace]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_a_namespace]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/v1_namespace_tenant-b.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/v1_namespace_tenant-b.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_b_namespace]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_b_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -19,4 +19,4 @@ metadata:
     cluster: cluster-east
     owner: platform-team
   name: tenant-b
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_b_namespace]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_b_namespace]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/v1_namespace_tenant-c.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-east/v1_namespace_tenant-c.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_c_namespace]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_c_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -19,4 +19,4 @@ metadata:
     cluster: cluster-east
     owner: platform-team
   name: tenant-c
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_east_tenant_c_namespace]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_east_tenant_c_namespace]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-a/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-a/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_a_role_binding]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_a_role_binding]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -31,4 +31,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-2
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_a_role_binding]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_a_role_binding]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-a/v1_resourcequota_hard-limit.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-a/v1_resourcequota_hard-limit.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_a_resource_quota]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_a_resource_quota]
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -25,4 +25,4 @@ spec:
     cpu: "100"
     memory: 10Gi
     pods: "10"
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_a_resource_quota]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_a_resource_quota]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-b/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-b/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_b_role_binding]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_b_role_binding]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -31,4 +31,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-12
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_b_role_binding]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_b_role_binding]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-b/v1_resourcequota_hard-limit.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-b/v1_resourcequota_hard-limit.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_b_resource_quota]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_b_resource_quota]
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -25,4 +25,4 @@ spec:
     cpu: "100"
     memory: 10Gi
     pods: "10"
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_b_resource_quota]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_b_resource_quota]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-c/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-c/rbac.authorization.k8s.io_v1_rolebinding_namespace-viewer.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_c_role_binding]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_c_role_binding]
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -31,4 +31,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-22
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_c_role_binding]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_c_role_binding]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-c/v1_resourcequota_hard-limit.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/namespaces/tenant-c/v1_resourcequota_hard-limit.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_c_resource_quota]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_c_resource_quota]
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -25,4 +25,4 @@ spec:
     cpu: "100"
     memory: 10Gi
     pods: "10"
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_c_resource_quota]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_c_resource_quota]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/v1_namespace_tenant-a.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/v1_namespace_tenant-a.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_a_namespace]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_a_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -19,4 +19,4 @@ metadata:
     cluster: cluster-west
     owner: platform-team
   name: tenant-a
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_a_namespace]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_a_namespace]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/v1_namespace_tenant-b.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/v1_namespace_tenant-b.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_b_namespace]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_b_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -19,4 +19,4 @@ metadata:
     cluster: cluster-west
     owner: platform-team
   name: tenant-b
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_b_namespace]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_b_namespace]

--- a/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/v1_namespace_tenant-c.yaml
+++ b/multi-cluster-access-and-quota/repos/platform/configsync/clusters/cluster-west/v1_namespace_tenant-c.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_c_namespace]
+# [START anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_c_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -19,4 +19,4 @@ metadata:
     cluster: cluster-west
     owner: platform-team
   name: tenant-c
-# [END anthos_config_management_multi_cluster_access_and_quota_cluster_west_tenant_c_namespace]
+# [END anthosconfig_multi_cluster_access_and_quota_cluster_west_tenant_c_namespace]

--- a/multi-cluster-access-and-quota/repos/platform/scripts/render.sh
+++ b/multi-cluster-access-and-quota/repos/platform/scripts/render.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/usr/bin/env bash
 
+# [START anthosconfig_scripts_render]
 # Render kustomizations
 
 set -o errexit -o nounset -o pipefail
@@ -48,3 +50,5 @@ for CLUSTER_PATH in "${SRC}/clusters/"*/; do
         done
     fi
 done
+
+# [END anthosconfig_scripts_render]

--- a/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces.yaml
+++ b/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces.yaml
@@ -11,29 +11,29 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_fanout_tenant_a_namespace] 
+# [START anthosconfig_multi_cluster_fanout_tenant_a_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
     owner: platform-team
   name: tenant-a
-# [END anthos_config_management_multi_cluster_fanout_tenant_a_namespace] 
+# [END anthosconfig_multi_cluster_fanout_tenant_a_namespace] 
 ---
-# [START anthos_config_management_multi_cluster_fanout_tenant_b_namespace] 
+# [START anthosconfig_multi_cluster_fanout_tenant_b_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
     owner: platform-team
   name: tenant-b
-# [END anthos_config_management_multi_cluster_fanout_tenant_b_namespace] 
+# [END anthosconfig_multi_cluster_fanout_tenant_b_namespace] 
 ---
-# [START anthos_config_management_multi_cluster_fanout_tenant_c_namespace] 
+# [START anthosconfig_multi_cluster_fanout_tenant_c_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
     owner: platform-team
   name: tenant-c
-# [END anthos_config_management_multi_cluster_fanout_tenant_c_namespace] 
+# [END anthosconfig_multi_cluster_fanout_tenant_c_namespace] 

--- a/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-a/quota.yaml
+++ b/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-a/quota.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_fanout_tenant_a_resource_quota] 
+# [START anthosconfig_multi_cluster_fanout_tenant_a_resource_quota] 
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -24,4 +24,4 @@ spec:
     cpu: "1000"
     memory: 100Gi
     pods: "100"
-# [END anthos_config_management_multi_cluster_fanout_tenant_a_resource_quota] 
+# [END anthosconfig_multi_cluster_fanout_tenant_a_resource_quota] 

--- a/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-a/rbac.yaml
+++ b/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-a/rbac.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_fanout_tenant_a_role_binding] 
+# [START anthosconfig_multi_cluster_fanout_tenant_a_role_binding] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -31,4 +31,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-a2
-# [END anthos_config_management_multi_cluster_fanout_tenant_a_role_binding] 
+# [END anthosconfig_multi_cluster_fanout_tenant_a_role_binding] 

--- a/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-b/quota.yaml
+++ b/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-b/quota.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_fanout_tenant_b_resource_quota] 
+# [START anthosconfig_multi_cluster_fanout_tenant_b_resource_quota] 
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -25,4 +25,4 @@ spec:
     cpu: "100"
     memory: 10Gi
     pods: "10"
-# [END anthos_config_management_multi_cluster_fanout_tenant_b_resource_quota] 
+# [END anthosconfig_multi_cluster_fanout_tenant_b_resource_quota] 

--- a/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-b/rbac.yaml
+++ b/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-b/rbac.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_fanout_tenant_b_role_binding] 
+# [START anthosconfig_multi_cluster_fanout_tenant_b_role_binding] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -31,4 +31,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-b2
-# [END anthos_config_management_multi_cluster_fanout_tenant_b_role_binding] 
+# [END anthosconfig_multi_cluster_fanout_tenant_b_role_binding] 

--- a/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-c/quota.yaml
+++ b/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-c/quota.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_fanout_tenant_c_resource_quota] 
+# [START anthosconfig_multi_cluster_fanout_tenant_c_resource_quota] 
 apiVersion: v1
 kind: ResourceQuota
 metadata:
@@ -25,4 +25,4 @@ spec:
     cpu: "100"
     memory: 10Gi
     pods: "10"
-# [END anthos_config_management_multi_cluster_fanout_tenant_c_resource_quota] 
+# [END anthosconfig_multi_cluster_fanout_tenant_c_resource_quota] 

--- a/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-c/rbac.yaml
+++ b/multi-cluster-fan-out/repos/platform/configsync/all-clusters/namespaces/tenant-c/rbac.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_fanout_tenant_c_role_binding] 
+# [START anthosconfig_multi_cluster_fanout_tenant_c_role_binding] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -31,4 +31,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: user-c2
-# [END anthos_config_management_multi_cluster_fanout_tenant_c_role_binding] 
+# [END anthosconfig_multi_cluster_fanout_tenant_c_role_binding] 

--- a/multi-cluster-ingress/repos/platform/configsync-src/all-clusters/gke-networking-rbac.yaml
+++ b/multi-cluster-ingress/repos/platform/configsync-src/all-clusters/gke-networking-rbac.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_platform_all_clusters_gke_networking_rbac] 
+# [START anthosconfig_multi_cluster_ingress_platform_all_clusters_gke_networking_rbac] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -37,4 +37,4 @@ rules:
 - apiGroups: ["networking.gke.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
-# [END anthos_config_management_multi_cluster_ingress_platform_all_clusters_gke_networking_rbac] 
+# [END anthosconfig_multi_cluster_ingress_platform_all_clusters_gke_networking_rbac] 

--- a/multi-cluster-ingress/repos/platform/configsync-src/all-clusters/kustomization.yaml
+++ b/multi-cluster-ingress/repos/platform/configsync-src/all-clusters/kustomization.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_platform_all_clusters_kustomization] 
+# [START anthosconfig_multi_cluster_ingress_platform_all_clusters_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - gke-networking-rbac.yaml
 - namespaces.yaml
-# [END anthos_config_management_multi_cluster_ingress_platform_all_clusters_kustomization] 
+# [END anthosconfig_multi_cluster_ingress_platform_all_clusters_kustomization] 

--- a/multi-cluster-ingress/repos/platform/configsync-src/all-clusters/namespaces.yaml
+++ b/multi-cluster-ingress/repos/platform/configsync-src/all-clusters/namespaces.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_platform_all_clusters_namespace_zoneprinter] 
+# [START anthosconfig_multi_cluster_ingress_platform_all_clusters_namespace_zoneprinter] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: zoneprinter
-# [END anthos_config_management_multi_cluster_ingress_platform_all_clusters_namespace_zoneprinter] 
+# [END anthosconfig_multi_cluster_ingress_platform_all_clusters_namespace_zoneprinter] 

--- a/multi-cluster-ingress/repos/platform/configsync-src/clusters/cluster-east/kustomization.yaml
+++ b/multi-cluster-ingress/repos/platform/configsync-src/clusters/cluster-east/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_platform_cluster_east_kustomization] 
+# [START anthosconfig_multi_cluster_ingress_platform_cluster_east_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -20,4 +20,4 @@ resources:
 commonLabels:
   cluster: cluster-east
   owner: platform-team
-# [END anthos_config_management_multi_cluster_ingress_platform_cluster_east_kustomization] 
+# [END anthosconfig_multi_cluster_ingress_platform_cluster_east_kustomization] 

--- a/multi-cluster-ingress/repos/platform/configsync-src/clusters/cluster-west/kustomization.yaml
+++ b/multi-cluster-ingress/repos/platform/configsync-src/clusters/cluster-west/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_platform_cluster_west_kustomization] 
+# [START anthosconfig_multi_cluster_ingress_platform_cluster_west_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -20,4 +20,4 @@ resources:
 commonLabels:
   cluster: cluster-west
   owner: platform-team
-# [END anthos_config_management_multi_cluster_ingress_platform_cluster_west_kustomization] 
+# [END anthosconfig_multi_cluster_ingress_platform_cluster_west_kustomization] 

--- a/multi-cluster-ingress/repos/platform/configsync/clusters/cluster-east/v1_namespace_zoneprinter.yaml
+++ b/multi-cluster-ingress/repos/platform/configsync/clusters/cluster-east/v1_namespace_zoneprinter.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_platform_cluster_east_namespace_zoneprinter] 
+# [START anthosconfig_multi_cluster_ingress_platform_cluster_east_namespace_zoneprinter] 
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -20,4 +20,4 @@ metadata:
     cluster: cluster-east
     owner: platform-team
   name: zoneprinter
-# [END anthos_config_management_multi_cluster_ingress_platform_cluster_east_namespace_zoneprinter] 
+# [END anthosconfig_multi_cluster_ingress_platform_cluster_east_namespace_zoneprinter] 

--- a/multi-cluster-ingress/repos/platform/configsync/clusters/cluster-west/v1_namespace_zoneprinter.yaml
+++ b/multi-cluster-ingress/repos/platform/configsync/clusters/cluster-west/v1_namespace_zoneprinter.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_platform_cluster_west_namespace_zoneprinter] 
+# [START anthosconfig_multi_cluster_ingress_platform_cluster_west_namespace_zoneprinter] 
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -20,4 +20,4 @@ metadata:
     cluster: cluster-west
     owner: platform-team
   name: zoneprinter
-# [END anthos_config_management_multi_cluster_ingress_platform_cluster_west_namespace_zoneprinter] 
+# [END anthosconfig_multi_cluster_ingress_platform_cluster_west_namespace_zoneprinter] 

--- a/multi-cluster-ingress/repos/platform/scripts/render.sh
+++ b/multi-cluster-ingress/repos/platform/scripts/render.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/usr/bin/env bash
 
+# [START anthosconfig_scripts_render]
 # Render kustomizations
 
 set -o errexit -o nounset -o pipefail
@@ -48,3 +50,5 @@ for CLUSTER_PATH in "${SRC}/clusters/"*/; do
         done
     fi
 done
+
+# [END anthosconfig_scripts_render]

--- a/multi-cluster-ingress/repos/zoneprinter/configsync-src/all-clusters/namespaces/zoneprinter/kustomization.yaml
+++ b/multi-cluster-ingress/repos/zoneprinter/configsync-src/all-clusters/namespaces/zoneprinter/kustomization.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_src_all_clusters_kustomization] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_src_all_clusters_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - zoneprinter-deployment.yaml
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_src_all_clusters_kustomization] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_src_all_clusters_kustomization] 

--- a/multi-cluster-ingress/repos/zoneprinter/configsync-src/all-clusters/namespaces/zoneprinter/zoneprinter-deployment.yaml
+++ b/multi-cluster-ingress/repos/zoneprinter/configsync-src/all-clusters/namespaces/zoneprinter/zoneprinter-deployment.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_src_all_clusters_deployment] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_src_all_clusters_deployment] 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -25,4 +25,4 @@ spec:
         image: gcr.io/google-samples/zone-printer:0.2
         ports:
         - containerPort: 8080
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_src_all_clusters_deployment] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_src_all_clusters_deployment] 

--- a/multi-cluster-ingress/repos/zoneprinter/configsync-src/clusters/cluster-east/namespaces/zoneprinter/kustomization.yaml
+++ b/multi-cluster-ingress/repos/zoneprinter/configsync-src/clusters/cluster-east/namespaces/zoneprinter/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_src_cluster_east_kustomization] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_src_cluster_east_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -22,4 +22,4 @@ commonLabels:
   app: zoneprinter
   owner: zoneprinter-team
   cluster: cluster-east
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_src_cluster_east_kustomization] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_src_cluster_east_kustomization] 

--- a/multi-cluster-ingress/repos/zoneprinter/configsync-src/clusters/cluster-west/namespaces/zoneprinter/kustomization.yaml
+++ b/multi-cluster-ingress/repos/zoneprinter/configsync-src/clusters/cluster-west/namespaces/zoneprinter/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_src_cluster_west_kustomization] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_src_cluster_west_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -23,4 +23,4 @@ commonLabels:
   app: zoneprinter
   owner: zoneprinter-team
   cluster: cluster-west
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_src_cluster_west_kustomization] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_src_cluster_west_kustomization] 

--- a/multi-cluster-ingress/repos/zoneprinter/configsync-src/clusters/cluster-west/namespaces/zoneprinter/mci.yaml
+++ b/multi-cluster-ingress/repos/zoneprinter/configsync-src/clusters/cluster-west/namespaces/zoneprinter/mci.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_src_cluster_west_mci] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_src_cluster_west_mci] 
 apiVersion: networking.gke.io/v1
 kind: MultiClusterIngress
 metadata:
@@ -23,9 +23,9 @@ spec:
       backend:
         serviceName: zoneprinter
         servicePort: 8080
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_src_cluster_west_mci] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_src_cluster_west_mci] 
 ---
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_src_cluster_west_mcs] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_src_cluster_west_mcs] 
 apiVersion: networking.gke.io/v1
 kind: MultiClusterService
 metadata:
@@ -40,4 +40,4 @@ spec:
         protocol: TCP
         port: 8080
         targetPort: 8080
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_src_cluster_west_mcs] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_src_cluster_west_mcs] 

--- a/multi-cluster-ingress/repos/zoneprinter/configsync/clusters/cluster-east/namespaces/zoneprinter/apps_v1_deployment_zoneprinter.yaml
+++ b/multi-cluster-ingress/repos/zoneprinter/configsync/clusters/cluster-east/namespaces/zoneprinter/apps_v1_deployment_zoneprinter.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_cluster_east_deployment] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_cluster_east_deployment] 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,4 +40,4 @@ spec:
         name: frontend
         ports:
         - containerPort: 8080
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_cluster_east_deployment] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_cluster_east_deployment] 

--- a/multi-cluster-ingress/repos/zoneprinter/configsync/clusters/cluster-west/namespaces/zoneprinter/apps_v1_deployment_zoneprinter.yaml
+++ b/multi-cluster-ingress/repos/zoneprinter/configsync/clusters/cluster-west/namespaces/zoneprinter/apps_v1_deployment_zoneprinter.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_cluster_west_deployment] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_cluster_west_deployment] 
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -40,4 +40,4 @@ spec:
         name: frontend
         ports:
         - containerPort: 8080
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_cluster_west_deployment] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_cluster_west_deployment] 

--- a/multi-cluster-ingress/repos/zoneprinter/configsync/clusters/cluster-west/namespaces/zoneprinter/networking.gke.io_v1_multiclusteringress_zoneprinter.yaml
+++ b/multi-cluster-ingress/repos/zoneprinter/configsync/clusters/cluster-west/namespaces/zoneprinter/networking.gke.io_v1_multiclusteringress_zoneprinter.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_cluster_west_mci] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_cluster_west_mci] 
 apiVersion: networking.gke.io/v1
 kind: MultiClusterIngress
 metadata:
@@ -28,4 +28,4 @@ spec:
       backend:
         serviceName: zoneprinter
         servicePort: 8080
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_cluster_west_mci] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_cluster_west_mci] 

--- a/multi-cluster-ingress/repos/zoneprinter/configsync/clusters/cluster-west/namespaces/zoneprinter/networking.gke.io_v1_multiclusterservice_zoneprinter.yaml
+++ b/multi-cluster-ingress/repos/zoneprinter/configsync/clusters/cluster-west/namespaces/zoneprinter/networking.gke.io_v1_multiclusterservice_zoneprinter.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_cluster_ingress_zoneprinter_cluster_west_mcs] 
+# [START anthosconfig_multi_cluster_ingress_zoneprinter_cluster_west_mcs] 
 apiVersion: networking.gke.io/v1
 kind: MultiClusterService
 metadata:
@@ -32,4 +32,4 @@ spec:
         targetPort: 8080
       selector:
         app: zoneprinter
-# [END anthos_config_management_multi_cluster_ingress_zoneprinter_cluster_west_mcs] 
+# [END anthosconfig_multi_cluster_ingress_zoneprinter_cluster_west_mcs] 

--- a/multi-cluster-ingress/repos/zoneprinter/scripts/render.sh
+++ b/multi-cluster-ingress/repos/zoneprinter/scripts/render.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# LimitRange Reference: https://kubernetes.io/docs/concepts/policy/limit-range/
-#!/usr/bin/env bash
 
+# LimitRange Reference: https://kubernetes.io/docs/concepts/policy/limit-range/
+# [START anthosconfig_scripts_render]
 # Render kustomizations
 
 set -o errexit -o nounset -o pipefail
@@ -49,3 +51,5 @@ for CLUSTER_PATH in "${SRC}/clusters/"*/; do
         done
     fi
 done
+
+# [END anthosconfig_scripts_render]

--- a/multi-environments-kustomize/cleanup.sh
+++ b/multi-environments-kustomize/cleanup.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/bin/bash
+
+# [START anthosconfig_multi_environments_kustomize_cleanup]
 
 if [[ -z "$DEV_PROJECT" ]]; then
     echo "Must provide DEV_PROJECT in environment" 1>&2
@@ -83,3 +86,5 @@ if [[ $CM_CONFIG_DIR == "cloud-build-rendering" ]]; then
     rm -rf foo-config-dev/
     rm -rf foo-config-prod/
 fi
+
+# [END anthosconfig_multi_environments_kustomize_cleanup]

--- a/multi-environments-kustomize/cloud-build-rendering/cloudbuilder-kustomize/Dockerfile
+++ b/multi-environments-kustomize/cloud-build-rendering/cloudbuilder-kustomize/Dockerfile
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_dockerfile] 
+# [START anthosconfig_multi_environments_kustomize_dockerfile] 
 FROM gcr.io/cloud-builders/kubectl:latest 
 RUN apt-get update && apt-get install -y wget 
 
 RUN wget https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.0.5/kustomize_v4.0.5_linux_amd64.tar.gz 
 
 RUN tar xf kustomize_v4.0.5_linux_amd64.tar.gz -C /usr/local/bin 
-# [END anthos_config_management_multi_environments_kustomize_dockerfile] 
+# [END anthosconfig_multi_environments_kustomize_dockerfile] 

--- a/multi-environments-kustomize/cloud-build-rendering/install-config/config-management-dev.yaml
+++ b/multi-environments-kustomize/cloud-build-rendering/install-config/config-management-dev.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_install_config_dev] 
+# [START anthosconfig_multi_environments_kustomize_install_config_dev] 
 applySpecVersion: 1
 spec:
   configSync:
@@ -26,4 +26,4 @@ spec:
     enabled: false
   hierarchyController:
     enabled: false
-# [END anthos_config_management_multi_environments_kustomize_install_config_dev] 
+# [END anthosconfig_multi_environments_kustomize_install_config_dev] 

--- a/multi-environments-kustomize/cloud-build-rendering/install-config/config-management-prod.yaml
+++ b/multi-environments-kustomize/cloud-build-rendering/install-config/config-management-prod.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_install_config_prod] 
+# [START anthosconfig_multi_environments_kustomize_install_config_prod] 
 applySpecVersion: 1
 spec:
   configSync:
@@ -26,4 +26,4 @@ spec:
     enabled: false
   hierarchyController:
     enabled: false
-# [END anthos_config_management_multi_environments_kustomize_install_config_prod] 
+# [END anthosconfig_multi_environments_kustomize_install_config_prod] 

--- a/multi-environments-kustomize/config-source/base/foo/kustomization.yaml
+++ b/multi-environments-kustomize/config-source/base/foo/kustomization.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_config_source_base_foo_kustomization] 
+# [START anthosconfig_multi_environments_kustomize_config_source_base_foo_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - namespace.yaml
 - serviceaccount.yaml
-# [END anthos_config_management_multi_environments_kustomize_config_source_base_foo_kustomization] 
+# [END anthosconfig_multi_environments_kustomize_config_source_base_foo_kustomization] 

--- a/multi-environments-kustomize/config-source/base/foo/namespace.yaml
+++ b/multi-environments-kustomize/config-source/base/foo/namespace.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_config_source_base_foo_namespace] 
+# [START anthosconfig_multi_environments_kustomize_config_source_base_foo_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: foo
-# [END anthos_config_management_multi_environments_kustomize_config_source_base_foo_namespace] 
+# [END anthosconfig_multi_environments_kustomize_config_source_base_foo_namespace] 

--- a/multi-environments-kustomize/config-source/base/foo/serviceaccount.yaml
+++ b/multi-environments-kustomize/config-source/base/foo/serviceaccount.yaml
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_config_source_base_foo_service_account] 
+# [START anthosconfig_multi_environments_kustomize_config_source_base_foo_service_account] 
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: foo-ksa
   namespace: foo
-# [END anthos_config_management_multi_environments_kustomize_config_source_base_foo_service_account] 
+# [END anthosconfig_multi_environments_kustomize_config_source_base_foo_service_account] 

--- a/multi-environments-kustomize/config-source/base/kustomization.yaml
+++ b/multi-environments-kustomize/config-source/base/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_config_source_base_kustomization] 
+# [START anthosconfig_multi_environments_kustomize_config_source_base_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
@@ -20,4 +20,4 @@ bases:
 resources:
 - pod-creator-clusterrole.yaml
 - pod-creator-rolebinding.yaml
-# [END anthos_config_management_multi_environments_kustomize_config_source_base_kustomization] 
+# [END anthosconfig_multi_environments_kustomize_config_source_base_kustomization] 

--- a/multi-environments-kustomize/config-source/base/pod-creator-clusterrole.yaml
+++ b/multi-environments-kustomize/config-source/base/pod-creator-clusterrole.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_config_source_base_cluster_role] 
+# [START anthosconfig_multi_environments_kustomize_config_source_base_cluster_role] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -22,4 +22,4 @@ rules:
   resources: ["pods"]
   verbs:
   - "*"
-# [END anthos_config_management_multi_environments_kustomize_config_source_base_cluster_role] 
+# [END anthosconfig_multi_environments_kustomize_config_source_base_cluster_role] 

--- a/multi-environments-kustomize/config-source/base/pod-creator-rolebinding.yaml
+++ b/multi-environments-kustomize/config-source/base/pod-creator-rolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_config_source_base_role_binding] 
+# [START anthosconfig_multi_environments_kustomize_config_source_base_role_binding] 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,4 +25,4 @@ roleRef:
   kind: ClusterRole
   name: pod-creator
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_multi_environments_kustomize_config_source_base_role_binding] 
+# [END anthosconfig_multi_environments_kustomize_config_source_base_role_binding] 

--- a/multi-environments-kustomize/config-source/cloudbuild.yaml
+++ b/multi-environments-kustomize/config-source/cloudbuild.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_config_source_cloudbuild] 
+# [START anthosconfig_multi_environments_kustomize_config_source_cloudbuild] 
 steps: 
 - name: 'gcr.io/google-samples/cloudbuild-kustomize:latest'
   id: Render foo-config-dev 
@@ -76,4 +76,4 @@ availableSecrets:
     env: 'GITHUB_TOKEN'
   - versionName: projects/${PROJECT_ID}/secrets/github-email/versions/1 
     env: 'GITHUB_EMAIL'
-# [END anthos_config_management_multi_environments_kustomize_config_source_cloudbuild] 
+# [END anthosconfig_multi_environments_kustomize_config_source_cloudbuild] 

--- a/multi-environments-kustomize/config-source/overlays/dev/kustomization.yaml
+++ b/multi-environments-kustomize/config-source/overlays/dev/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_config_source_overlays_dev_kustomization] 
+# [START anthosconfig_multi_environments_kustomize_config_source_overlays_dev_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
@@ -36,4 +36,4 @@ patches:
       value: developers-all@foo-corp.com
 commonLabels:
   environment: dev
-# [END anthos_config_management_multi_environments_kustomize_config_source_overlays_dev_kustomization] 
+# [END anthosconfig_multi_environments_kustomize_config_source_overlays_dev_kustomization] 

--- a/multi-environments-kustomize/config-source/overlays/prod/kustomization.yaml
+++ b/multi-environments-kustomize/config-source/overlays/prod/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_config_source_overlays_prod_kustomization] 
+# [START anthosconfig_multi_environments_kustomize_config_source_overlays_prod_kustomization] 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
@@ -36,4 +36,4 @@ patches:
       value: deploy-bot@foo-corp.com
 commonLabels:
   environment: prod
-# [END anthos_config_management_multi_environments_kustomize_config_source_overlays_prod_kustomization] 
+# [END anthosconfig_multi_environments_kustomize_config_source_overlays_prod_kustomization] 

--- a/multi-environments-kustomize/config-sync-rendering/install-config/config-management-dev.yaml
+++ b/multi-environments-kustomize/config-sync-rendering/install-config/config-management-dev.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_install_config_dev] 
+# [START anthosconfig_multi_environments_kustomize_install_config_dev] 
 applySpecVersion: 1
 spec:
   configSync:
@@ -26,4 +26,4 @@ spec:
     enabled: false
   hierarchyController:
     enabled: false
-# [END anthos_config_management_multi_environments_kustomize_install_config_dev] 
+# [END anthosconfig_multi_environments_kustomize_install_config_dev] 

--- a/multi-environments-kustomize/config-sync-rendering/install-config/config-management-prod.yaml
+++ b/multi-environments-kustomize/config-sync-rendering/install-config/config-management-prod.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_multi_environments_kustomize_install_config_prod] 
+# [START anthosconfig_multi_environments_kustomize_install_config_prod] 
 applySpecVersion: 1
 spec:
   configSync:
@@ -26,4 +26,4 @@ spec:
     enabled: false
   hierarchyController:
     enabled: false
-# [END anthos_config_management_multi_environments_kustomize_install_config_prod] 
+# [END anthosconfig_multi_environments_kustomize_install_config_prod] 

--- a/multi-environments-kustomize/create-clusters.sh
+++ b/multi-environments-kustomize/create-clusters.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/bin/bash
+
+# [START anthosconfig_multi_environments_kustomize_create_clusters]
 
 if [[ -z "$DEV_PROJECT" ]]; then
     echo "Must provide DEV_PROJECT in environment" 1>&2
@@ -67,3 +70,5 @@ gcloud container clusters get-credentials dev --zone ${DEV_CLUSTER_ZONE} --proje
 gcloud container clusters get-credentials prod --zone ${PROD_CLUSTER_ZONE} --project ${PROD_PROJECT}
 
 echo "⭐️ Done creating clusters."
+
+# [END anthosconfig_multi_environments_kustomize_create_clusters]

--- a/multi-environments-kustomize/create-repos.sh
+++ b/multi-environments-kustomize/create-repos.sh
@@ -1,6 +1,5 @@
 # !/bin/bash
 
-# [START anthosconfig_multi_environments_kustomize_create_repos]
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/multi-environments-kustomize/create-repos.sh
+++ b/multi-environments-kustomize/create-repos.sh
@@ -1,3 +1,6 @@
+# !/bin/bash
+
+# [START anthosconfig_multi_environments_kustomize_create_repos]
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# !/bin/bash
+
+# [START anthosconfig_multi_environments_kustomize_create_repos]
 
 if [[ -z "$GITHUB_USERNAME" ]]; then
     echo "Must provide GITHUB_USERNAME in environment" 1>&2
@@ -67,3 +71,5 @@ git checkout -b main
 echo "Foo Config Prod" >> README.md
 git add .; git commit -m "Initialize"; git push origin main 
 cd ..  
+
+# [END anthosconfig_multi_environments_kustomize_create_repos]

--- a/multi-environments-kustomize/install-config-sync.sh
+++ b/multi-environments-kustomize/install-config-sync.sh
@@ -1,3 +1,6 @@
+# !/bin/bash
+
+# [START anthosconfig_multi_environments_kustomize_install_config_sync]
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +14,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# !/bin/bash
+
+# [START anthosconfig_multi_environments_kustomize_install_config_sync]
 
 if [[ -z "$DEV_PROJECT" ]]; then
     echo "Must provide DEV_PROJECT in environment" 1>&2
@@ -68,3 +72,5 @@ gcloud alpha container hub config-management apply \
     --membership=prod \
     --config="$CM_CONFIG_DIR/install-config/config-management-prod.yaml" \
     --project=${PROD_PROJECT}
+
+# [END anthosconfig_multi_environments_kustomize_install_config_sync]

--- a/multi-environments-kustomize/install-config-sync.sh
+++ b/multi-environments-kustomize/install-config-sync.sh
@@ -1,6 +1,5 @@
 # !/bin/bash
 
-# [START anthosconfig_multi_environments_kustomize_install_config_sync]
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/multi-environments-kustomize/register-clusters.sh
+++ b/multi-environments-kustomize/register-clusters.sh
@@ -1,3 +1,5 @@
+# !/bin/bash
+
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# !/bin/bash
+
+# [START anthosconfig_multi_environments_kustomize_register_clusters]
 
 if [[ -z "$DEV_PROJECT" ]]; then
     echo "Must provide DEV_PROJECT in environment" 1>&2
@@ -84,3 +87,5 @@ gcloud config set project $PROD_PROJECT
 gcloud alpha container hub config-management enable
 
 echo "⭐️ Done registering clusters."
+
+# [END anthosconfig_multi_environments_kustomize_register_clusters]

--- a/multi-environments-kustomize/secret-manager-git.sh
+++ b/multi-environments-kustomize/secret-manager-git.sh
@@ -1,3 +1,5 @@
+# !/bin/bash
+
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# !/bin/bash
+
+# [START anthosconfig_multi_environments_kustomize_secret_manager_git]
 
 if [[ -z "$PROD_PROJECT" ]]; then
     echo "Must provide PROD_PROJECT in environment" 1>&2
@@ -52,3 +55,5 @@ gcloud projects add-iam-policy-binding ${PROD_PROJECT} \
     --member="serviceAccount:${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com" \
     --role='roles/secretmanager.secretAccessor'
 
+
+# [END anthosconfig_multi_environments_kustomize_secret_manager_git]

--- a/namespace-inheritance/compiled/analytics/networkpolicy_allow-gamestore-ingress.yaml
+++ b/namespace-inheritance/compiled/analytics/networkpolicy_allow-gamestore-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_analytics_network_policy_allow_gamestore_ingress] 
+# [START anthosconfig_namespace_inheritance_compiled_analytics_network_policy_allow_gamestore_ingress] 
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -31,4 +31,4 @@ spec:
   podSelector:
     matchLabels:
       app: gamestore
-# [END anthos_config_management_namespace_inheritance_compiled_analytics_network_policy_allow_gamestore_ingress] 
+# [END anthosconfig_namespace_inheritance_compiled_analytics_network_policy_allow_gamestore_ingress] 

--- a/namespace-inheritance/compiled/analytics/networkpolicy_default-deny-all-traffic.yaml
+++ b/namespace-inheritance/compiled/analytics/networkpolicy_default-deny-all-traffic.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_analytics_network_policy_default_deny_all] 
+# [START anthosconfig_namespace_inheritance_compiled_analytics_network_policy_default_deny_all] 
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -27,4 +27,4 @@ metadata:
   namespace: analytics
 spec:
   podSelector: {}
-# [END anthos_config_management_namespace_inheritance_compiled_analytics_network_policy_default_deny_all] 
+# [END anthosconfig_namespace_inheritance_compiled_analytics_network_policy_default_deny_all] 

--- a/namespace-inheritance/compiled/analytics/resourcequota_quota.yaml
+++ b/namespace-inheritance/compiled/analytics/resourcequota_quota.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_analytics_resource_quota] 
+# [START anthosconfig_namespace_inheritance_compiled_analytics_resource_quota] 
 ---
 apiVersion: v1
 kind: ResourceQuota
@@ -31,4 +31,4 @@ spec:
     cpu: 100m
     memory: 100Mi
     pods: "1"
-# [END anthos_config_management_namespace_inheritance_compiled_analytics_resource_quota] 
+# [END anthosconfig_namespace_inheritance_compiled_analytics_resource_quota] 

--- a/namespace-inheritance/compiled/analytics/role_eng-viewer.yaml
+++ b/namespace-inheritance/compiled/analytics/role_eng-viewer.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_analytics_role_eng_viewer] 
+# [START anthosconfig_namespace_inheritance_compiled_analytics_role_eng_viewer] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -33,4 +33,4 @@ rules:
   verbs:
   - get
   - list
-# [END anthos_config_management_namespace_inheritance_compiled_analytics_role_eng_viewer] 
+# [END anthosconfig_namespace_inheritance_compiled_analytics_role_eng_viewer] 

--- a/namespace-inheritance/compiled/analytics/rolebinding_eng-admin.yaml
+++ b/namespace-inheritance/compiled/analytics/rolebinding_eng-admin.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_analytics_role_binding_eng_admin] 
+# [START anthosconfig_namespace_inheritance_compiled_analytics_role_binding_eng_admin] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -33,4 +33,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: eng@example.com
-# [END anthos_config_management_namespace_inheritance_compiled_analytics_role_binding_eng_admin] 
+# [END anthosconfig_namespace_inheritance_compiled_analytics_role_binding_eng_admin] 

--- a/namespace-inheritance/compiled/analytics/rolebinding_viewers.yaml
+++ b/namespace-inheritance/compiled/analytics/rolebinding_viewers.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_analytics_role_binding_viewers] 
+# [START anthosconfig_namespace_inheritance_compiled_analytics_role_binding_viewers] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -33,4 +33,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:serviceaccounts:foo
-# [END anthos_config_management_namespace_inheritance_compiled_analytics_role_binding_viewers] 
+# [END anthosconfig_namespace_inheritance_compiled_analytics_role_binding_viewers] 

--- a/namespace-inheritance/compiled/clusterrole_foo-admin.yaml
+++ b/namespace-inheritance/compiled/clusterrole_foo-admin.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_cluster_role_foo_admin] 
+# [START anthosconfig_namespace_inheritance_compiled_cluster_role_foo_admin] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -45,4 +45,4 @@ rules:
   verbs:
   - get
   - list
-# [END anthos_config_management_namespace_inheritance_compiled_cluster_role_foo_admin] 
+# [END anthosconfig_namespace_inheritance_compiled_cluster_role_foo_admin] 

--- a/namespace-inheritance/compiled/clusterrole_namespace-reader.yaml
+++ b/namespace-inheritance/compiled/clusterrole_namespace-reader.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_cluster_role_namespace_reader] 
+# [START anthosconfig_namespace_inheritance_compiled_cluster_role_namespace_reader] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -33,4 +33,4 @@ rules:
   - get
   - watch
   - list
-# [END anthos_config_management_namespace_inheritance_compiled_cluster_role_namespace_reader] 
+# [END anthosconfig_namespace_inheritance_compiled_cluster_role_namespace_reader] 

--- a/namespace-inheritance/compiled/clusterrole_rbac-viewer.yaml
+++ b/namespace-inheritance/compiled/clusterrole_rbac-viewer.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_cluster_role_rbac_viewer] 
+# [START anthosconfig_namespace_inheritance_compiled_cluster_role_rbac_viewer] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -35,4 +35,4 @@ rules:
   verbs:
   - get
   - list
-# [END anthos_config_management_namespace_inheritance_compiled_cluster_role_rbac_viewer] 
+# [END anthosconfig_namespace_inheritance_compiled_cluster_role_rbac_viewer] 

--- a/namespace-inheritance/compiled/clusterrolebinding_namespace-readers.yaml
+++ b/namespace-inheritance/compiled/clusterrolebinding_namespace-readers.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_cluster_role_binding_namespace_readers] 
+# [START anthosconfig_namespace_inheritance_compiled_cluster_role_binding_namespace_readers] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -32,4 +32,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: cheryl@example.com
-# [END anthos_config_management_namespace_inheritance_compiled_cluster_role_binding_namespace_readers] 
+# [END anthosconfig_namespace_inheritance_compiled_cluster_role_binding_namespace_readers] 

--- a/namespace-inheritance/compiled/clusterrolebinding_rbac-viewers.yaml
+++ b/namespace-inheritance/compiled/clusterrolebinding_rbac-viewers.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_cluster_role_binding_rbac_viewers] 
+# [START anthosconfig_namespace_inheritance_compiled_cluster_role_binding_rbac_viewers] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -32,4 +32,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: cheryl@example.com
-# [END anthos_config_management_namespace_inheritance_compiled_cluster_role_binding_rbac_viewers] 
+# [END anthosconfig_namespace_inheritance_compiled_cluster_role_binding_rbac_viewers] 

--- a/namespace-inheritance/compiled/gamestore/configmap_store-inventory.yaml
+++ b/namespace-inheritance/compiled/gamestore/configmap_store-inventory.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_gamestore_configmap] 
+# [START anthosconfig_namespace_inheritance_compiled_gamestore_configmap] 
 ---
 apiVersion: v1
 data:
@@ -30,4 +30,4 @@ metadata:
     configsync.gke.io/declared-version: v1
   name: store-inventory
   namespace: gamestore
-# [END anthos_config_management_namespace_inheritance_compiled_gamestore_configmap] 
+# [END anthosconfig_namespace_inheritance_compiled_gamestore_configmap] 

--- a/namespace-inheritance/compiled/gamestore/networkpolicy_allow-gamestore-ingress.yaml
+++ b/namespace-inheritance/compiled/gamestore/networkpolicy_allow-gamestore-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_gamestore_network_policy_allow_gamestore_ingress] 
+# [START anthosconfig_namespace_inheritance_compiled_gamestore_network_policy_allow_gamestore_ingress] 
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -31,4 +31,4 @@ spec:
   podSelector:
     matchLabels:
       app: gamestore
-# [END anthos_config_management_namespace_inheritance_compiled_gamestore_network_policy_allow_gamestore_ingress] 
+# [END anthosconfig_namespace_inheritance_compiled_gamestore_network_policy_allow_gamestore_ingress] 

--- a/namespace-inheritance/compiled/gamestore/networkpolicy_default-deny-all-traffic.yaml
+++ b/namespace-inheritance/compiled/gamestore/networkpolicy_default-deny-all-traffic.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_gamestore_network_policy_default_deny_all_traffic] 
+# [START anthosconfig_namespace_inheritance_compiled_gamestore_network_policy_default_deny_all_traffic] 
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -27,4 +27,4 @@ metadata:
   namespace: gamestore
 spec:
   podSelector: {}
-# [END anthos_config_management_namespace_inheritance_compiled_gamestore_network_policy_default_deny_all_traffic] 
+# [END anthosconfig_namespace_inheritance_compiled_gamestore_network_policy_default_deny_all_traffic] 

--- a/namespace-inheritance/compiled/gamestore/resourcequota_quota.yaml
+++ b/namespace-inheritance/compiled/gamestore/resourcequota_quota.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_gamestore_resource_quota] 
+# [START anthosconfig_namespace_inheritance_compiled_gamestore_resource_quota] 
 ---
 apiVersion: v1
 kind: ResourceQuota
@@ -31,4 +31,4 @@ spec:
     cpu: 200m
     memory: 200Mi
     pods: "1"
-# [END anthos_config_management_namespace_inheritance_compiled_gamestore_resource_quota] 
+# [END anthosconfig_namespace_inheritance_compiled_gamestore_resource_quota] 

--- a/namespace-inheritance/compiled/gamestore/role_eng-viewer.yaml
+++ b/namespace-inheritance/compiled/gamestore/role_eng-viewer.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_gamestore_role_eng_viewer] 
+# [START anthosconfig_namespace_inheritance_compiled_gamestore_role_eng_viewer] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -33,4 +33,4 @@ rules:
   verbs:
   - get
   - list
-# [END anthos_config_management_namespace_inheritance_compiled_gamestore_role_eng_viewer] 
+# [END anthosconfig_namespace_inheritance_compiled_gamestore_role_eng_viewer] 

--- a/namespace-inheritance/compiled/gamestore/rolebinding_bob-rolebinding.yaml
+++ b/namespace-inheritance/compiled/gamestore/rolebinding_bob-rolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_gamestore_role_binding_bob] 
+# [START anthosconfig_namespace_inheritance_compiled_gamestore_role_binding_bob] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -33,4 +33,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: User
   name: bob@example.com
-# [END anthos_config_management_namespace_inheritance_compiled_gamestore_role_binding_bob] 
+# [END anthosconfig_namespace_inheritance_compiled_gamestore_role_binding_bob] 

--- a/namespace-inheritance/compiled/gamestore/rolebinding_eng-admin.yaml
+++ b/namespace-inheritance/compiled/gamestore/rolebinding_eng-admin.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_gamestore_role_binding_eng_admin] 
+# [START anthosconfig_namespace_inheritance_compiled_gamestore_role_binding_eng_admin] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -33,4 +33,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: eng@example.com
-# [END anthos_config_management_namespace_inheritance_compiled_gamestore_role_binding_eng_admin] 
+# [END anthosconfig_namespace_inheritance_compiled_gamestore_role_binding_eng_admin] 

--- a/namespace-inheritance/compiled/gamestore/rolebinding_viewers.yaml
+++ b/namespace-inheritance/compiled/gamestore/rolebinding_viewers.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_gamestore_role_binding_viewers] 
+# [START anthosconfig_namespace_inheritance_compiled_gamestore_role_binding_viewers] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -33,4 +33,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:serviceaccounts:foo
-# [END anthos_config_management_namespace_inheritance_compiled_gamestore_role_binding_viewers] 
+# [END anthosconfig_namespace_inheritance_compiled_gamestore_role_binding_viewers] 

--- a/namespace-inheritance/compiled/incubator-1/networkpolicy_default-deny-all-traffic.yaml
+++ b/namespace-inheritance/compiled/incubator-1/networkpolicy_default-deny-all-traffic.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_incubator_1_network_policy_default_deny_all_traffic] 
+# [START anthosconfig_namespace_inheritance_compiled_incubator_1_network_policy_default_deny_all_traffic] 
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -27,4 +27,4 @@ metadata:
   namespace: incubator-1
 spec:
   podSelector: {}
-# [END anthos_config_management_namespace_inheritance_compiled_incubator_1_network_policy_default_deny_all_traffic] 
+# [END anthosconfig_namespace_inheritance_compiled_incubator_1_network_policy_default_deny_all_traffic] 

--- a/namespace-inheritance/compiled/incubator-1/role_incubator-1-admin.yaml
+++ b/namespace-inheritance/compiled/incubator-1/role_incubator-1-admin.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_incubator_1_role_admin] 
+# [START anthosconfig_namespace_inheritance_compiled_incubator_1_role_admin] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -46,4 +46,4 @@ rules:
   verbs:
   - get
   - list
-# [END anthos_config_management_namespace_inheritance_compiled_incubator_1_role_admin] 
+# [END anthosconfig_namespace_inheritance_compiled_incubator_1_role_admin] 

--- a/namespace-inheritance/compiled/incubator-1/rolebinding_viewers.yaml
+++ b/namespace-inheritance/compiled/incubator-1/rolebinding_viewers.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_incubator_1_role_binding_viewers] 
+# [START anthosconfig_namespace_inheritance_compiled_incubator_1_role_binding_viewers] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -33,4 +33,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:serviceaccounts:foo
-# [END anthos_config_management_namespace_inheritance_compiled_incubator_1_role_binding_viewers] 
+# [END anthosconfig_namespace_inheritance_compiled_incubator_1_role_binding_viewers] 

--- a/namespace-inheritance/compiled/incubator-2/networkpolicy_default-deny-all-traffic.yaml
+++ b/namespace-inheritance/compiled/incubator-2/networkpolicy_default-deny-all-traffic.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_incubator_2_network_policy_default_deny_all_traffic] 
+# [START anthosconfig_namespace_inheritance_compiled_incubator_2_network_policy_default_deny_all_traffic] 
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -27,4 +27,4 @@ metadata:
   namespace: incubator-2
 spec:
   podSelector: {}
-# [END anthos_config_management_namespace_inheritance_compiled_incubator_2_network_policy_default_deny_all_traffic] 
+# [END anthosconfig_namespace_inheritance_compiled_incubator_2_network_policy_default_deny_all_traffic] 

--- a/namespace-inheritance/compiled/incubator-2/rolebinding_viewers.yaml
+++ b/namespace-inheritance/compiled/incubator-2/rolebinding_viewers.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_incubator_2_role_binding] 
+# [START anthosconfig_namespace_inheritance_compiled_incubator_2_role_binding] 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -33,4 +33,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: system:serviceaccounts:foo
-# [END anthos_config_management_namespace_inheritance_compiled_incubator_2_role_binding] 
+# [END anthosconfig_namespace_inheritance_compiled_incubator_2_role_binding] 

--- a/namespace-inheritance/compiled/namespace_analytics.yaml
+++ b/namespace-inheritance/compiled/namespace_analytics.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_namespace_analytics] 
+# [START anthosconfig_namespace_inheritance_compiled_namespace_analytics] 
 ---
 apiVersion: v1
 kind: Namespace
@@ -28,4 +28,4 @@ metadata:
     configsync.gke.io/declared-version: v1
     eng.tree.hnc.x-k8s.io/depth: "1"
   name: analytics
-# [END anthos_config_management_namespace_inheritance_compiled_namespace_analytics] 
+# [END anthosconfig_namespace_inheritance_compiled_namespace_analytics] 

--- a/namespace-inheritance/compiled/namespace_gamestore.yaml
+++ b/namespace-inheritance/compiled/namespace_gamestore.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_namespace_gamestore] 
+# [START anthosconfig_namespace_inheritance_compiled_namespace_gamestore] 
 ---
 apiVersion: v1
 kind: Namespace
@@ -29,4 +29,4 @@ metadata:
     eng.tree.hnc.x-k8s.io/depth: "1"
     gamestore.tree.hnc.x-k8s.io/depth: "0"
   name: gamestore
-# [END anthos_config_management_namespace_inheritance_compiled_namespace_gamestore] 
+# [END anthosconfig_namespace_inheritance_compiled_namespace_gamestore] 

--- a/namespace-inheritance/compiled/namespace_incubator-1.yaml
+++ b/namespace-inheritance/compiled/namespace_incubator-1.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_namespace_incubator_1] 
+# [START anthosconfig_namespace_inheritance_compiled_namespace_incubator_1] 
 ---
 apiVersion: v1
 kind: Namespace
@@ -27,4 +27,4 @@ metadata:
     incubator-1.tree.hnc.x-k8s.io/depth: "0"
     rnd.tree.hnc.x-k8s.io/depth: "1"
   name: incubator-1
-# [END anthos_config_management_namespace_inheritance_compiled_namespace_incubator_1] 
+# [END anthosconfig_namespace_inheritance_compiled_namespace_incubator_1] 

--- a/namespace-inheritance/compiled/namespace_incubator-2.yaml
+++ b/namespace-inheritance/compiled/namespace_incubator-2.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_compiled_namespace_incubator_2] 
+# [START anthosconfig_namespace_inheritance_compiled_namespace_incubator_2] 
 ---
 apiVersion: v1
 kind: Namespace
@@ -27,4 +27,4 @@ metadata:
     incubator-2.tree.hnc.x-k8s.io/depth: "0"
     rnd.tree.hnc.x-k8s.io/depth: "1"
   name: incubator-2
-# [END anthos_config_management_namespace_inheritance_compiled_namespace_incubator_2] 
+# [END anthosconfig_namespace_inheritance_compiled_namespace_incubator_2] 

--- a/namespace-inheritance/config/cluster/admin-clusterrole.yaml
+++ b/namespace-inheritance/config/cluster/admin-clusterrole.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_cluster_role_foo_admin] 
+# [START anthosconfig_namespace_inheritance_config_cluster_role_foo_admin] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -27,4 +27,4 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]
   verbs: ["get", "list"]
-# [END anthos_config_management_namespace_inheritance_config_cluster_role_foo_admin] 
+# [END anthosconfig_namespace_inheritance_config_cluster_role_foo_admin] 

--- a/namespace-inheritance/config/cluster/namespace-reader-clusterrole.yaml
+++ b/namespace-inheritance/config/cluster/namespace-reader-clusterrole.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_cluster_role_namespace_reader] 
+# [START anthosconfig_namespace_inheritance_config_cluster_role_namespace_reader] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,4 +21,4 @@ rules:
 - apiGroups: [""]
   resources: ["namespaces"]
   verbs: ["get", "watch", "list"]
-# [END anthos_config_management_namespace_inheritance_config_cluster_role_namespace_reader] 
+# [END anthosconfig_namespace_inheritance_config_cluster_role_namespace_reader] 

--- a/namespace-inheritance/config/cluster/namespace-reader-clusterrolebinding.yaml
+++ b/namespace-inheritance/config/cluster/namespace-reader-clusterrolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_cluster_role_binding_namespace_readers] 
+# [START anthosconfig_namespace_inheritance_config_cluster_role_binding_namespace_readers] 
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,4 +25,4 @@ roleRef:
   kind: ClusterRole
   name: namespace-reader
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_namespace_inheritance_config_cluster_role_binding_namespace_readers] 
+# [END anthosconfig_namespace_inheritance_config_cluster_role_binding_namespace_readers] 

--- a/namespace-inheritance/config/cluster/rbac-viewer-clusterrole.yaml
+++ b/namespace-inheritance/config/cluster/rbac-viewer-clusterrole.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_cluster_role_rbac_viewer] 
+# [START anthosconfig_namespace_inheritance_config_cluster_role_rbac_viewer] 
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -21,4 +21,4 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings", "clusterroles", "clusterrolebindings"]
   verbs: ["get", "list"]
-# [END anthos_config_management_namespace_inheritance_config_cluster_role_rbac_viewer] 
+# [END anthosconfig_namespace_inheritance_config_cluster_role_rbac_viewer] 

--- a/namespace-inheritance/config/cluster/rbac-viewers.yaml
+++ b/namespace-inheritance/config/cluster/rbac-viewers.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_cluster_role_bindings_rbac_viewers] 
+# [START anthosconfig_namespace_inheritance_config_cluster_role_bindings_rbac_viewers] 
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,4 +25,4 @@ roleRef:
   kind: ClusterRole
   name: rbac-viewer
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_namespace_inheritance_config_cluster_role_bindings_rbac_viewers] 
+# [END anthosconfig_namespace_inheritance_config_cluster_role_bindings_rbac_viewers] 

--- a/namespace-inheritance/config/namespaces/eng/analytics/namespace.yaml
+++ b/namespace-inheritance/config/namespaces/eng/analytics/namespace.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_analytics_namespace] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_analytics_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: analytics
   labels:
     app: analytics
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_analytics_namespace] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_analytics_namespace] 

--- a/namespace-inheritance/config/namespaces/eng/eng-role.yaml
+++ b/namespace-inheritance/config/namespaces/eng/eng-role.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_role] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_role] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -21,4 +21,4 @@ rules:
   - apiGroups: [""]
     resources: ["*"]
     verbs: ["get", "list"]
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_role] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_role] 

--- a/namespace-inheritance/config/namespaces/eng/eng-roleinding.yaml
+++ b/namespace-inheritance/config/namespaces/eng/eng-roleinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_role_binding] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_role_binding] 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,4 +25,4 @@ roleRef:
   kind: Role
   name: eng-viewer
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_role_binding] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_role_binding] 

--- a/namespace-inheritance/config/namespaces/eng/gamestore/bob-rolebinding.yaml
+++ b/namespace-inheritance/config/namespaces/eng/gamestore/bob-rolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_gamestore_bob_role_binding] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_gamestore_bob_role_binding] 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,4 +25,4 @@ roleRef:
   kind: ClusterRole
   name: foo-admin
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_gamestore_bob_role_binding] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_gamestore_bob_role_binding] 

--- a/namespace-inheritance/config/namespaces/eng/gamestore/inventory-configmap.yaml
+++ b/namespace-inheritance/config/namespaces/eng/gamestore/inventory-configmap.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_gamestore_configmap_store_inventory] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_gamestore_configmap_store_inventory] 
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -23,4 +23,4 @@ data:
   action: "30"
   documentary: "5"
   sci_fi: "1000"
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_gamestore_configmap_store_inventory] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_gamestore_configmap_store_inventory] 

--- a/namespace-inheritance/config/namespaces/eng/gamestore/namespace.yaml
+++ b/namespace-inheritance/config/namespaces/eng/gamestore/namespace.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_gamestore_namespace] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_gamestore_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -21,4 +21,4 @@ metadata:
     app: gamestore
   annotations:
     retail: "true"
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_gamestore_namespace] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_gamestore_namespace] 

--- a/namespace-inheritance/config/namespaces/eng/network-policy-allow-gamestore-ingress.yaml
+++ b/namespace-inheritance/config/namespaces/eng/network-policy-allow-gamestore-ingress.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_network_policy_allow_gamestore_ingress] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_network_policy_allow_gamestore_ingress] 
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
@@ -23,4 +23,4 @@ spec:
       app: gamestore
   ingress:
     - {}
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_network_policy_allow_gamestore_ingress] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_network_policy_allow_gamestore_ingress] 

--- a/namespace-inheritance/config/namespaces/eng/quota.yaml
+++ b/namespace-inheritance/config/namespaces/eng/quota.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_resource_quota_analytics_selector] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_resource_quota_analytics_selector] 
 kind: ResourceQuota
 apiVersion: v1
 metadata:
@@ -24,9 +24,9 @@ spec:
     pods: "1"
     cpu: "100m"
     memory: 100Mi
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_resource_quota_analytics_selector] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_resource_quota_analytics_selector] 
 ---
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_resource_quota_gamestore_selector] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_resource_quota_gamestore_selector] 
 kind: ResourceQuota
 apiVersion: v1
 metadata:
@@ -38,4 +38,4 @@ spec:
     pods: "1"
     cpu: "200m"
     memory: 200Mi
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_resource_quota_gamestore_selector] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_resource_quota_gamestore_selector] 

--- a/namespace-inheritance/config/namespaces/eng/selectors.yaml
+++ b/namespace-inheritance/config/namespaces/eng/selectors.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_namespace_selector_analytics] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_namespace_selector_analytics] 
 kind: NamespaceSelector
 apiVersion: configmanagement.gke.io/v1
 metadata:
@@ -21,9 +21,9 @@ spec:
   selector:
     matchLabels:
       app: analytics
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_namespace_selector_analytics] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_namespace_selector_analytics] 
 ---
-# [START anthos_config_management_namespace_inheritance_config_namespaces_eng_namespace_selector_gamestore] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_eng_namespace_selector_gamestore] 
 kind: NamespaceSelector
 apiVersion: configmanagement.gke.io/v1
 metadata:
@@ -32,4 +32,4 @@ spec:
   selector:
     matchLabels:
       app: gamestore
-# [END anthos_config_management_namespace_inheritance_config_namespaces_eng_namespace_selector_gamestore] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_eng_namespace_selector_gamestore] 

--- a/namespace-inheritance/config/namespaces/network-policy-default-deny-all.yaml
+++ b/namespace-inheritance/config/namespaces/network-policy-default-deny-all.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_network_policy_default_deny_all_traffic] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_network_policy_default_deny_all_traffic] 
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: default-deny-all-traffic
 spec:
   podSelector: {}
-# [END anthos_config_management_namespace_inheritance_config_namespaces_network_policy_default_deny_all_traffic] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_network_policy_default_deny_all_traffic] 

--- a/namespace-inheritance/config/namespaces/rnd/incubator-1/incubator-1-admin-role.yaml
+++ b/namespace-inheritance/config/namespaces/rnd/incubator-1/incubator-1-admin-role.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_rnd_role] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_rnd_role] 
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -27,4 +27,4 @@ rules:
 - apiGroups: ["rbac.authorization.k8s.io"]
   resources: ["roles", "rolebindings"]
   verbs: ["get", "list"]
-# [END anthos_config_management_namespace_inheritance_config_namespaces_rnd_role] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_rnd_role] 

--- a/namespace-inheritance/config/namespaces/rnd/incubator-1/namespace.yaml
+++ b/namespace-inheritance/config/namespaces/rnd/incubator-1/namespace.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_rnd_namespace_incubator_1] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_rnd_namespace_incubator_1] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: incubator-1
-# [END anthos_config_management_namespace_inheritance_config_namespaces_rnd_namespace_incubator_1] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_rnd_namespace_incubator_1] 

--- a/namespace-inheritance/config/namespaces/rnd/incubator-2/namespace.yaml
+++ b/namespace-inheritance/config/namespaces/rnd/incubator-2/namespace.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_rnd_namespace_incubator_2] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_rnd_namespace_incubator_2] 
 apiVersion: v1
 kind: Namespace
 metadata:
    name: incubator-2
-# [END anthos_config_management_namespace_inheritance_config_namespaces_rnd_namespace_incubator_2] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_rnd_namespace_incubator_2] 

--- a/namespace-inheritance/config/namespaces/viewers-rolebinding.yaml
+++ b/namespace-inheritance/config/namespaces/viewers-rolebinding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_config_namespaces_role_binding_viewers] 
+# [START anthosconfig_namespace_inheritance_config_namespaces_role_binding_viewers] 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -25,4 +25,4 @@ roleRef:
   kind: ClusterRole
   name: view
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_namespace_inheritance_config_namespaces_role_binding_viewers] 
+# [END anthosconfig_namespace_inheritance_config_namespaces_role_binding_viewers] 

--- a/namespace-inheritance/config/system/repo.yaml
+++ b/namespace-inheritance/config/system/repo.yaml
@@ -12,11 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_inheritance_repo] 
+# [START anthosconfig_namespace_inheritance_repo] 
 apiVersion: configmanagement.gke.io/v1
 kind: Repo
 metadata:
   name: repo
 spec:
   version: 1.0.0
-# [END anthos_config_management_namespace_inheritance_repo] 
+# [END anthosconfig_namespace_inheritance_repo] 

--- a/namespace-specific-policy/automated-rendering/kustomization.yaml
+++ b/namespace-specific-policy/automated-rendering/kustomization.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_automated_rendering_kustomization]
+# [START anthosconfig_namespace_specific_policy_automated_rendering_kustomization]
 resources:
 - configsync-src/team-a
 - configsync-src/team-b
 - configsync-src/team-c
-# [END anthos_config_management_namespace_specific_policy_automated_rendering_kustomization]
+# [END anthosconfig_namespace_specific_policy_automated_rendering_kustomization]

--- a/namespace-specific-policy/configsync-src/base/kustomization.yaml
+++ b/namespace-specific-policy/configsync-src/base/kustomization.yaml
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_src_base_kustomization] 
+# [START anthosconfig_namespace_specific_policy_src_base_kustomization] 
 resources:
 - namespace.yaml
 - rolebinding.yaml
 - role.yaml
 - networkpolicy.yaml
-# [END anthos_config_management_namespace_specific_policy_src_base_kustomization] 
+# [END anthosconfig_namespace_specific_policy_src_base_kustomization] 

--- a/namespace-specific-policy/configsync-src/base/namespace.yaml
+++ b/namespace-specific-policy/configsync-src/base/namespace.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_src_base_namespace] 
+# [START anthosconfig_namespace_specific_policy_src_base_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: default
-# [END anthos_config_management_namespace_specific_policy_src_base_namespace] 
+# [END anthosconfig_namespace_specific_policy_src_base_namespace] 

--- a/namespace-specific-policy/configsync-src/base/networkpolicy.yaml
+++ b/namespace-specific-policy/configsync-src/base/networkpolicy.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # deny all ingress traffic to avoid Pods from one namespace
 # accidentally sending traffic to Services in other namespaces.
-# [START anthos_config_management_namespace_specific_policy_src_base_network_policy] 
+# [START anthosconfig_namespace_specific_policy_src_base_network_policy] 
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -24,4 +24,4 @@ spec:
   ingress:
   - from:
     - podSelector: {}
-# [END anthos_config_management_namespace_specific_policy_src_base_network_policy] 
+# [END anthosconfig_namespace_specific_policy_src_base_network_policy] 

--- a/namespace-specific-policy/configsync-src/base/role.yaml
+++ b/namespace-specific-policy/configsync-src/base/role.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # deny all ingress traffic to avoid Pods from one namespace
 # accidentally sending traffic to Services in other namespaces.
-# [START anthos_config_management_namespace_specific_policy_src_base_role] 
+# [START anthosconfig_namespace_specific_policy_src_base_role] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -22,4 +22,4 @@ rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]
   verbs: ["*"]
-# [END anthos_config_management_namespace_specific_policy_src_base_role] 
+# [END anthosconfig_namespace_specific_policy_src_base_role] 

--- a/namespace-specific-policy/configsync-src/base/rolebinding.yaml
+++ b/namespace-specific-policy/configsync-src/base/rolebinding.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # deny all ingress traffic to avoid Pods from one namespace
 # accidentally sending traffic to Services in other namespaces.
-# [START anthos_config_management_namespace_specific_policy_src_base_role_binding] 
+# [START anthosconfig_namespace_specific_policy_src_base_role_binding] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -26,4 +26,4 @@ roleRef:
   kind: Role
   name: team-admin
   apiGroup: rbac.authorization.k8s.io
-# [END anthos_config_management_namespace_specific_policy_src_base_role_binding] 
+# [END anthosconfig_namespace_specific_policy_src_base_role_binding] 

--- a/namespace-specific-policy/configsync-src/team-a/kustomization.yaml
+++ b/namespace-specific-policy/configsync-src/team-a/kustomization.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # deny all ingress traffic to avoid Pods from one namespace
 # accidentally sending traffic to Services in other namespaces.
-# [START anthos_config_management_namespace_specific_policy_src_team_a_kustomization] 
+# [START anthosconfig_namespace_specific_policy_src_team_a_kustomization] 
 namespace: team-a
 
 resources:
@@ -34,4 +34,4 @@ patches:
     - op: replace
       path: /metadata/name
       value: team-a
-# [END anthos_config_management_namespace_specific_policy_src_team_a_kustomization] 
+# [END anthosconfig_namespace_specific_policy_src_team_a_kustomization] 

--- a/namespace-specific-policy/configsync-src/team-b/kustomization.yaml
+++ b/namespace-specific-policy/configsync-src/team-b/kustomization.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # deny all ingress traffic to avoid Pods from one namespace
 # accidentally sending traffic to Services in other namespaces.
-# [START anthos_config_management_namespace_specific_policy_src_team_b_kustomization] 
+# [START anthosconfig_namespace_specific_policy_src_team_b_kustomization] 
 namespace: team-b
 
 resources:
@@ -34,4 +34,4 @@ patches:
     - op: replace
       path: /metadata/name
       value: team-b
-# [END anthos_config_management_namespace_specific_policy_src_team_b_kustomization] 
+# [END anthosconfig_namespace_specific_policy_src_team_b_kustomization] 

--- a/namespace-specific-policy/configsync-src/team-c/kustomization.yaml
+++ b/namespace-specific-policy/configsync-src/team-c/kustomization.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 # deny all ingress traffic to avoid Pods from one namespace
 # accidentally sending traffic to Services in other namespaces.
-# [START anthos_config_management_namespace_specific_policy_src_team_c_kustomization] 
+# [START anthosconfig_namespace_specific_policy_src_team_c_kustomization] 
 namespace: team-c
 
 resources:
@@ -34,4 +34,4 @@ patches:
     - op: replace
       path: /metadata/name
       value: team-c
-# [END anthos_config_management_namespace_specific_policy_src_team_c_kustomization] 
+# [END anthosconfig_namespace_specific_policy_src_team_c_kustomization] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-a/networking.k8s.io_v1_networkpolicy_deny-all.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-a/networking.k8s.io_v1_networkpolicy_deny-all.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_a_network_policy] 
+# [START anthosconfig_namespace_specific_policy_team_a_network_policy] 
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -23,4 +23,4 @@ spec:
     - podSelector: {}
   podSelector:
     matchLabels: null
-# [END anthos_config_management_namespace_specific_policy_team_a_network_policy] 
+# [END anthosconfig_namespace_specific_policy_team_a_network_policy] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-a/rbac.authorization.k8s.io_v1_role_team-admin.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-a/rbac.authorization.k8s.io_v1_role_team-admin.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_specific_policy_team_a_role] 
+# [START anthosconfig_namespace_specific_policy_team_a_role] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -25,4 +25,4 @@ rules:
   - deployments
   verbs:
   - '*'
-# [END anthos_config_management_namespace_specific_policy_team_a_role] 
+# [END anthosconfig_namespace_specific_policy_team_a_role] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-a/rbac.authorization.k8s.io_v1_rolebinding_team-admin-rolebinding.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-a/rbac.authorization.k8s.io_v1_rolebinding_team-admin-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_a_role_binding] 
+# [START anthosconfig_namespace_specific_policy_team_a_role_binding] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -25,4 +25,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: team-a-admin@mydomain.com
-# [END anthos_config_management_namespace_specific_policy_team_a_role_binding] 
+# [END anthosconfig_namespace_specific_policy_team_a_role_binding] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-a/v1_namespace_team-a.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-a/v1_namespace_team-a.yaml
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# [START anthos_config_management_namespace_specific_policy_team_a_namespace] 
+# [START anthosconfig_namespace_specific_policy_team_a_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: team-a
-# [END anthos_config_management_namespace_specific_policy_team_a_namespace] 
+# [END anthosconfig_namespace_specific_policy_team_a_namespace] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-b/networking.k8s.io_v1_networkpolicy_deny-all.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-b/networking.k8s.io_v1_networkpolicy_deny-all.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_b_network_policy] 
+# [START anthosconfig_namespace_specific_policy_team_b_network_policy] 
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -23,4 +23,4 @@ spec:
     - podSelector: {}
   podSelector:
     matchLabels: null
-# [END anthos_config_management_namespace_specific_policy_team_b_network_policy] 
+# [END anthosconfig_namespace_specific_policy_team_b_network_policy] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-b/rbac.authorization.k8s.io_v1_role_team-admin.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-b/rbac.authorization.k8s.io_v1_role_team-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_b_role] 
+# [START anthosconfig_namespace_specific_policy_team_b_role] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -24,4 +24,4 @@ rules:
   - deployments
   verbs:
   - '*'
-# [END anthos_config_management_namespace_specific_policy_team_b_role] 
+# [END anthosconfig_namespace_specific_policy_team_b_role] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-b/rbac.authorization.k8s.io_v1_rolebinding_team-admin-rolebinding.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-b/rbac.authorization.k8s.io_v1_rolebinding_team-admin-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_b_role_binding] 
+# [START anthosconfig_namespace_specific_policy_team_b_role_binding] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -25,4 +25,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: team-b-admin@mydomain.com
-# [END anthos_config_management_namespace_specific_policy_team_b_role_binding] 
+# [END anthosconfig_namespace_specific_policy_team_b_role_binding] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-b/v1_namespace_team-b.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-b/v1_namespace_team-b.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_b_namespace] 
+# [START anthosconfig_namespace_specific_policy_team_b_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: team-b
-# [END anthos_config_management_namespace_specific_policy_team_b_namespace] 
+# [END anthosconfig_namespace_specific_policy_team_b_namespace] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-c/networking.k8s.io_v1_networkpolicy_deny-all.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-c/networking.k8s.io_v1_networkpolicy_deny-all.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_c_network_policy] 
+# [START anthosconfig_namespace_specific_policy_team_c_network_policy] 
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -23,4 +23,4 @@ spec:
     - podSelector: {}
   podSelector:
     matchLabels: null
-# [END anthos_config_management_namespace_specific_policy_team_c_network_policy] 
+# [END anthosconfig_namespace_specific_policy_team_c_network_policy] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-c/rbac.authorization.k8s.io_v1_role_team-admin.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-c/rbac.authorization.k8s.io_v1_role_team-admin.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_c_role] 
+# [START anthosconfig_namespace_specific_policy_team_c_role] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -24,4 +24,4 @@ rules:
   - deployments
   verbs:
   - '*'
-# [END anthos_config_management_namespace_specific_policy_team_c_role] 
+# [END anthosconfig_namespace_specific_policy_team_c_role] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-c/rbac.authorization.k8s.io_v1_rolebinding_team-admin-rolebinding.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-c/rbac.authorization.k8s.io_v1_rolebinding_team-admin-rolebinding.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_c_role_binding] 
+# [START anthosconfig_namespace_specific_policy_team_c_role_binding] 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -25,4 +25,4 @@ subjects:
 - apiGroup: rbac.authorization.k8s.io
   kind: Group
   name: team-c-admin@mydomain.com
-# [END anthos_config_management_namespace_specific_policy_team_c_role_binding] 
+# [END anthosconfig_namespace_specific_policy_team_c_role_binding] 

--- a/namespace-specific-policy/manual-rendering/configsync/team-c/v1_namespace_team-c.yaml
+++ b/namespace-specific-policy/manual-rendering/configsync/team-c/v1_namespace_team-c.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_namespace_specific_policy_team_c_namespace] 
+# [START anthosconfig_namespace_specific_policy_team_c_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: team-c
-# [END anthos_config_management_namespace_specific_policy_team_c_namespace] 
+# [END anthosconfig_namespace_specific_policy_team_c_namespace] 

--- a/namespace-specific-policy/manual-rendering/scripts/render.sh
+++ b/namespace-specific-policy/manual-rendering/scripts/render.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/bin/bash
 
+# [START anthosconfig_scripts_render]
 # Render kustomizations
 
 set -o errexit -o nounset -o pipefail
@@ -27,3 +29,5 @@ for team in team-*; do
         kustomize build ${team} -o ../manual-rendering/configsync/${team}/
     fi
 done
+
+# [END anthosconfig_scripts_render]

--- a/quickstart/config-sync/namespaces/hello.yaml
+++ b/quickstart/config-sync/namespaces/hello.yaml
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_quickstart_namespaces_hello_namespace] 
+# [START anthosconfig_quickstart_namespaces_hello_namespace] 
 apiVersion: v1
 kind: Namespace
 metadata:
   name: hello
-# [END anthos_config_management_quickstart_namespaces_hello_namespace] 
+# [END anthosconfig_quickstart_namespaces_hello_namespace] 

--- a/quickstart/config-sync/namespaces/hello.yaml
+++ b/quickstart/config-sync/namespaces/hello.yaml
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START anthosconfig_quickstart_namespaces_hello_namespace] 
+# [START anthos_config_management_quickstart_namespaces_hello_namespace]
 apiVersion: v1
 kind: Namespace
 metadata:
   name: hello
+# [END anthos_config_management_quickstart_namespaces_hello_namespace]
 # [END anthosconfig_quickstart_namespaces_hello_namespace] 

--- a/quickstart/config-sync/policies/no-ext-services.yaml
+++ b/quickstart/config-sync/policies/no-ext-services.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_quickstart_policies_no_ext_services] 
+# [START anthosconfig_quickstart_policies_no_ext_services] 
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sNoExternalServices
 metadata:
@@ -19,4 +19,4 @@ metadata:
 spec:
   parameters:
     internalCIDRs: []
-# [END anthos_config_management_quickstart_policies_no_ext_services] 
+# [END anthosconfig_quickstart_policies_no_ext_services] 

--- a/quickstart/config-sync/policies/no-ext-services.yaml
+++ b/quickstart/config-sync/policies/no-ext-services.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START anthosconfig_quickstart_policies_no_ext_services] 
+# [START anthos_config_management_quickstart_policies_no_ext_services] 
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sNoExternalServices
 metadata:
@@ -19,4 +20,5 @@ metadata:
 spec:
   parameters:
     internalCIDRs: []
+# [END anthos_config_management_quickstart_policies_no_ext_services] 
 # [END anthosconfig_quickstart_policies_no_ext_services] 

--- a/quickstart/resources/service.yaml
+++ b/quickstart/resources/service.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# [START anthos_config_management_quickstart_resources_service_hello] 
+# [START anthosconfig_quickstart_resources_service_hello] 
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,4 +25,4 @@ spec:
   - name: http
     port: 80
     targetPort: 8080
-# [END anthos_config_management_quickstart_resources_service_hello] 
+# [END anthosconfig_quickstart_resources_service_hello] 

--- a/quickstart/resources/service.yaml
+++ b/quickstart/resources/service.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # [START anthosconfig_quickstart_resources_service_hello] 
+# [START anthos_config_management_quickstart_resources_service_hello] 
 apiVersion: v1
 kind: Service
 metadata:
@@ -25,4 +26,5 @@ spec:
   - name: http
     port: 80
     targetPort: 8080
+# [END anthos_config_management_quickstart_resources_service_hello] 
 # [END anthosconfig_quickstart_resources_service_hello] 


### PR DESCRIPTION
### Fixes 
n/a

#### Description
Ongoing effort of adding region tags to our yaml and shell files in our repos. Allows for our team to leverage internal tool

#### Change summary
* Added region tags. Snippet-bot will add a comment below of the tags added (and where).
* Changed previously tagged `anthos_config_mangement` tags to `anthosconfig`

#### Related PRs/Issues
Similar PRs can be found here [microservice-demo PR](https://github.com/GoogleCloudPlatform/microservices-demo/pull/684), [bank-of-anthos PR](https://github.com/GoogleCloudPlatform/bank-of-anthos/pull/611)



