### PR TITLE
fix branch name in kpt pkg get (1.0.0 doesn't exist anymore)

### DIFF
--- a/ci-app/app-repo/cloudbuild.yaml
+++ b/ci-app/app-repo/cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
   # and consolidates every resource in a single file.
   name: 'gcr.io/kpt-dev/kpt'
   entrypoint: '/bin/sh'
-  args: ['-c', 'kpt pkg get https://github.com/GoogleCloudPlatform/anthos-config-management-samples.git/ci-app/acm-repo/cluster@1.0.0 constraints
+  args: ['-c', 'kpt pkg get https://github.com/GoogleCloudPlatform/anthos-config-management-samples.git/ci-app/acm-repo/cluster@main constraints
                   && kpt fn source constraints/ hydrated-manifests/ > hydrated-manifests/kpt-manifests.yaml']
 - id: 'Validate against policies'
   # This step validates that all resources comply with all policies.


### PR DESCRIPTION
Fix internal b/230486560.

Fix issue in this tutorial https://cloud.google.com/anthos-config-management/docs/tutorials/app-policy-validation-ci-pipeline.

Branch `1.0.0` doesn't exist (anymore).

With the error with the `1.0.0` branch:
```bash
kpt pkg get https://github.com/GoogleCloudPlatform/anthos-config-management-samples.git/ci-app/acm-repo/cluster@1.0.0 constraints
```
```output
Error: Unknown ref "1.0.0". Please verify that the reference exists in upstream repo "https://github.com/GoogleCloudPlatform/anthos-config-management-samples".
```

With the fix with the `main` branch
```bash
kpt pkg get https://github.com/GoogleCloudPlatform/anthos-config-management-samples.git/ci-app/acm-repo/cluster@main constraints
```
```output
From https://github.com/GoogleCloudPlatform/anthos-config-management-samples
 * branch            main       -> FETCH_HEAD
Adding package "ci-app/acm-repo/cluster".

Fetched 1 package(s).
```
```bash
ls constraints
```
```output
deployment-must-have-owner.yaml  Kptfile  requiredlabels.yaml
```

