### PR TITLE
Update cloudbuild.yaml

### DIFF
--- a/ci-app/app-repo/cloudbuild.yaml
+++ b/ci-app/app-repo/cloudbuild.yaml
@@ -29,6 +29,6 @@ steps:
                   && kpt fn source constraints/ hydrated-manifests/ > hydrated-manifests/kpt-manifests.yaml']
 - id: 'Validate against policies'
   # This step validates that all resources comply with all policies.
-  name: 'gcr.io/config-management-release/policy-controller-validate'
+  name: 'gcr.io/kpt-fn/gatekeeper'
   args: ['--input', 'hydrated-manifests/kpt-manifests.yaml']
 # [END cloudbuild_config]


### PR DESCRIPTION
policy-controller-validate function is out of date, pointing to the gatekeeper kpt function for more up to date validate features, we will remove the policy-controller-validate function to ensure we do not have multiple kpt functions for the same functionality