### PR TITLE
Fix `ci-app`'s Cloud Build definition with `gcr.io/kpt-fn/gatekeeper` container image tag

### DIFF
--- a/ci-app/app-repo/cloudbuild.yaml
+++ b/ci-app/app-repo/cloudbuild.yaml
@@ -29,6 +29,6 @@ steps:
                   && kpt fn source constraints/ hydrated-manifests/ > hydrated-manifests/kpt-manifests.yaml']
 - id: 'Validate against policies'
   # This step validates that all resources comply with all policies.
-  name: 'gcr.io/kpt-fn/gatekeeper'
+  name: 'gcr.io/kpt-fn/gatekeeper:v0.2'
   args: ['--input', 'hydrated-manifests/kpt-manifests.yaml']
 # [END cloudbuild_config]


### PR DESCRIPTION
Fix `gcr.io/kpt-fn/gatekeeper:v0.2` container image in Cloud Build definition of the https://cloud.google.com/anthos-config-management/docs/tutorials/app-policy-validation-ci-pipeline tutorial.

`latest` doesn't work: https://github.com/GoogleContainerTools/kpt/issues/3134

Following up on this https://github.com/GoogleCloudPlatform/anthos-config-management-samples/pull/45.

CC: @poonam-lamba 