### PR TITLE
ASM/ACM Tutorial - Add `AsmAuthzPolicyEnforceSourcePrincipals` `Constraint` illustration

### DIFF
--- a/asm-acm-tutorial/root-sync/enforce-authorization-policies/policies/authz-source-principals-not-all.yaml
+++ b/asm-acm-tutorial/root-sync/enforce-authorization-policies/policies/authz-source-principals-not-all.yaml
@@ -1,0 +1,14 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: AsmAuthzPolicyEnforceSourcePrincipals
+metadata:
+  name: authz-source-principals-not-all
+spec:
+  enforcementAction: deny
+  match:
+    kinds:
+    - apiGroups:
+      - security.istio.io
+      kinds:
+      - AuthorizationPolicy
+    excludedNamespaces:
+      - asm-ingress

--- a/asm-acm-tutorial/root-sync/enforce-authorization-policies/policies/authz-source-principals-not-all.yaml
+++ b/asm-acm-tutorial/root-sync/enforce-authorization-policies/policies/authz-source-principals-not-all.yaml
@@ -1,3 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START anthosconfig_policies_authz_source_principals_not_all_asmauthzpolicyenforcesourceprincipals_authz_source_principals_not_all]
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: AsmAuthzPolicyEnforceSourcePrincipals
 metadata:
@@ -12,3 +27,4 @@ spec:
       - AuthorizationPolicy
     excludedNamespaces:
       - asm-ingress
+# [END anthosconfig_policies_authz_source_principals_not_all_asmauthzpolicyenforcesourceprincipals_authz_source_principals_not_all]

--- a/asm-acm-tutorial/root-sync/enforce-authorization-policies/policies/kustomization.yaml
+++ b/asm-acm-tutorial/root-sync/enforce-authorization-policies/policies/kustomization.yaml
@@ -17,4 +17,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - default-deny-authorization-policies.yaml
+- authz-source-principals-not-all.yaml
 # [END anthosconfig_enforce_authorization_policies_policies_kustomization_kustomization]


### PR DESCRIPTION
Add the [`AsmAuthzPolicyEnforceSourcePrincipals`](https://cloud.devsite.corp.google.com/anthos-config-management/docs/reference/latest/constraint-template-library#asmauthzpolicyenforcesourceprincipals) `Constraint` to complete the story of the [ASM/ACM Tutorial](https://cloud.google.com/anthos-config-management/docs/tutorials/strengthen-app-security#enforce_authorizationpolicies).