### PR TITLE
Change paths for the ACM ASM tutorial config syncs [do not merge yet]

### DIFF
--- a/asm-acm-tutorial/online-boutique/authorization-policies/kustomization.yaml
+++ b/asm-acm-tutorial/online-boutique/authorization-policies/kustomization.yaml
@@ -18,8 +18,8 @@ kind: Kustomization
 resources:
 - ../deployments
 components:
-- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/docs/online-boutique-asm-manifests/service-accounts/all?ref=main
-- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/docs/online-boutique-asm-manifests/authorization-policies/all?ref=main
+- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/online-boutique-asm-manifests/service-accounts/all?ref=main
+- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/online-boutique-asm-manifests/authorization-policies/all?ref=main
 - for-ingress-gateway
 namespace: onlineboutique
 # [END anthosconfig_online_boutique_authorization_policies_kustomization_kustomization]

--- a/asm-acm-tutorial/online-boutique/deployments/kustomization.yaml
+++ b/asm-acm-tutorial/online-boutique/deployments/kustomization.yaml
@@ -17,7 +17,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: onlineboutique
 resources:
-- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/docs/online-boutique-asm-manifests/base/all?ref=main
+- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/online-boutique-asm-manifests/base/all?ref=main
 patchesStrategicMerge:
 - |-
   apiVersion: v1

--- a/asm-acm-tutorial/root-sync/deploy-authorization-policies/ingress-gateway/kustomization.yaml
+++ b/asm-acm-tutorial/root-sync/deploy-authorization-policies/ingress-gateway/kustomization.yaml
@@ -16,6 +16,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 components:
-- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/docs/ingress-gateway-asm-manifests/with-authorization-policies?ref=main
+- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/addons/ingress-gateway-asm-manifests/with-authorization-policies?ref=main
 namespace: asm-ingress
 # [END anthosconfig_deploy_authorization_policies_ingress_gateway_kustomization_kustomization]

--- a/asm-acm-tutorial/root-sync/deployments/ingress-gateway/kustomization.yaml
+++ b/asm-acm-tutorial/root-sync/deployments/ingress-gateway/kustomization.yaml
@@ -16,6 +16,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/docs/ingress-gateway-asm-manifests/base?ref=main
+- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/addons/ingress-gateway-asm-manifests/base?ref=main
 namespace: asm-ingress
 # [END anthosconfig_deployments_ingress_gateway_kustomization_kustomization]

--- a/asm-acm-tutorial/root-sync/fix-default-deny-authorization-policy/default-deny-authorization-policy/kustomization.yaml
+++ b/asm-acm-tutorial/root-sync/fix-default-deny-authorization-policy/default-deny-authorization-policy/kustomization.yaml
@@ -16,6 +16,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/docs/istio-system-manifests/with-default-deny-authorization-policy?ref=main
+- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/addons/istio-system-manifests/with-default-deny-authorization-policy?ref=main
 namespace: istio-system
 # [END anthosconfig_fix_default_deny_authorization_policy_default_deny_authorization_policy_kustomization_kustomization]

--- a/asm-acm-tutorial/root-sync/fix-strict-mtls/enable-mesh-strict-mtls/kustomization.yaml
+++ b/asm-acm-tutorial/root-sync/fix-strict-mtls/enable-mesh-strict-mtls/kustomization.yaml
@@ -16,6 +16,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/docs/istio-system-manifests/with-strict-mtls?ref=main
+- github.com/GoogleCloudPlatform/anthos-service-mesh-samples/addons/istio-system-manifests/with-strict-mtls?ref=main
 namespace: istio-system
 # [END anthosconfig_fix_strict_mtls_enable_mesh_strict_mtls_kustomization_kustomization]


### PR DESCRIPTION
Reworking the ASM samples repo. The yaml files changed in this PR are related to a config sync tutorial that relies on ASM samples. 
Changes involved are changing the paths. 

_Do not merge yet till the ASM samples repo PR is merged_