### PR TITLE
update `gcloud container hub`-->`fleet` commands + `alpha` --> `beta`

### DIFF
--- a/helm-component/manual-rendering/README.md
+++ b/helm-component/manual-rendering/README.md
@@ -95,7 +95,7 @@ You can also configure the Git repository information in a config-management.yam
     ```
 1.  Apply the config-management.yaml file:
     ```console
-    gcloud alpha container hub config-management apply \
+    gcloud beta container fleet config-management apply \
         --membership=CLUSTER_NAME \
         --config=CONFIG_YAML_PATH \
         --project=PROJECT_ID
@@ -115,7 +115,7 @@ You can also configure the Git repository information in a config-management.yam
 ### Using gcloud
 Run the following command to get the status
 ```console
-gcloud alpha container hub config-management status --project=PROJECT_ID
+gcloud beta container fleet config-management status --project=PROJECT_ID
 ```
 Replace `PROJECT_ID` with your project's ID.
 

--- a/hierarchical-format/README.md
+++ b/hierarchical-format/README.md
@@ -55,7 +55,7 @@ You can also configure the Git repository information in a YAML file and use `gc
     ```
 1.  Apply the config-management.yaml file:
     ```console
-    gcloud alpha container hub config-management apply \
+    gcloud beta container fleet config-management apply \
         --membership=CLUSTER_NAME \
         --config=CONFIG_YAML_PATH \
         --project=PROJECT_ID
@@ -75,7 +75,7 @@ You can also configure the Git repository information in a YAML file and use `gc
 ### Using gcloud
 Run the following command to get the status
 ```console
-gcloud alpha container hub config-management status --project=PROJECT_ID
+gcloud beta container fleet config-management status --project=PROJECT_ID
 ```
 Replace `PROJECT_ID` with your project's ID.
 

--- a/multi-cluster-access-and-quota/README.md
+++ b/multi-cluster-access-and-quota/README.md
@@ -231,11 +231,11 @@ spec:
     secretType: none
 EOF
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-west" \
   --config config-management-west.yaml
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-east" \
   --config config-management-east.yaml
 
@@ -260,7 +260,7 @@ This triggers the following actions:
 **Lookup the Config Sync status:**
 
 ```
-gcloud alpha container hub config-management status
+gcloud beta container fleet config-management status
 ```
 
 Should say "SYNCED" for both clusters with the latest commit SHA.
@@ -367,7 +367,7 @@ git push
 **Wait for config to be synchronized:**
 
 ```
-gcloud alpha container hub config-management status
+gcloud beta container fleet config-management status
 ```
 
 Should say "SYNCED" for both clusters with the latest commit SHA.
@@ -384,11 +384,11 @@ spec:
     enabled: false
 EOF
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-west" \
   --config config-management.yaml
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-east" \
   --config config-management.yaml
 

--- a/multi-cluster-acm-setup/README.md
+++ b/multi-cluster-acm-setup/README.md
@@ -191,11 +191,11 @@ Registering with Hub will install the Connect Agent on the cluster. To make perm
 **Register a GKE cluster using Workload Identity (recommended):**
 
 ```
-gcloud container hub memberships register "cluster-west" \
+gcloud container fleet memberships register "cluster-west" \
     --gke-cluster us-west1/cluster-west \
     --enable-workload-identity
 
-gcloud container hub memberships register "cluster-east" \
+gcloud container fleet memberships register "cluster-east" \
     --gke-cluster us-east1/cluster-east \
     --enable-workload-identity
 ```
@@ -213,7 +213,7 @@ These operators are all managed as features using Hub.
 **Enable ACM on the Hub:**
 
 ```
-gcloud alpha container hub config-management enable
+gcloud beta container fleet config-management enable
 ```
 
 The ACM Operator will not be installed until one of its components is enabled and configured.

--- a/multi-cluster-fan-out/README.md
+++ b/multi-cluster-fan-out/README.md
@@ -136,11 +136,11 @@ spec:
     secretType: none
 EOF
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-west" \
   --config config-management.yaml
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-east" \
   --config config-management.yaml
 
@@ -164,7 +164,7 @@ This triggers the following actions:
 **Lookup the Config Sync status:**
 
 ```
-gcloud alpha container hub config-management status
+gcloud beta container fleet config-management status
 ```
 
 Should say "SYNCED" for both clusters with the latest commit SHA.
@@ -260,7 +260,7 @@ git push
 **Wait for config to be synchronized:**
 
 ```
-gcloud alpha container hub config-management status
+gcloud beta container fleet config-management status
 ```
 
 Should say "SYNCED" for both clusters with the latest commit SHA.
@@ -277,11 +277,11 @@ spec:
     enabled: false
 EOF
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-west" \
   --config config-management.yaml
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-east" \
   --config config-management.yaml
 

--- a/multi-cluster-ingress/README.md
+++ b/multi-cluster-ingress/README.md
@@ -223,7 +223,7 @@ git push
 # Enable Multi-Cluster Ingress via Hub
 
 ```
-gcloud alpha container hub ingress enable \
+gcloud container fleet ingress enable \
     --config-membership projects/${PLATFORM_PROJECT_ID}/locations/global/memberships/cluster-west
 ```
 
@@ -264,11 +264,11 @@ spec:
     secretType: none
 EOF
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-west" \
   --config config-management-west.yaml
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-east" \
   --config config-management-east.yaml
 
@@ -425,7 +425,7 @@ git push
 **Lookup the Config Sync status:**
 
 ```
-gcloud alpha container hub config-management status
+gcloud beta container fleet config-management status
 ```
 
 Should say "SYNCED" for both clusters with the latest commit SHA.
@@ -581,7 +581,7 @@ git rev-parse --short HEAD
 **Wait for config to be synchronized:**
 
 ```
-gcloud alpha container hub config-management status
+gcloud beta container fleet config-management status
 ```
 
 Should say "SYNCED" for both clusters with the latest commit SHA.
@@ -598,11 +598,11 @@ spec:
     enabled: false
 EOF
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-west" \
   --config config-management.yaml
 
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
   --membership "cluster-east" \
   --config config-management.yaml
 
@@ -630,6 +630,6 @@ rm -rf "${WORKSPACE}/platform/"
 **Disable Multi-Cluster Ingress via Hub:**
 
 ```
-gcloud alpha container hub ingress disable \
+gcloud container fleet ingress disable \
     --config-membership projects/${PLATFORM_PROJECT_ID}/locations/global/memberships/cluster-west
 ```

--- a/multi-environments-kustomize/cleanup.sh
+++ b/multi-environments-kustomize/cleanup.sh
@@ -43,10 +43,10 @@ fi
 
 echo "Turning off Anthos Config Management.."
 gcloud config set project $DEV_PROJECT
-gcloud alpha container hub config-management disable 
+gcloud beta container fleet config-management disable 
 
 gcloud config set project $PROD_PROJECT
-gcloud alpha container hub config-management disable 
+gcloud beta container fleet config-management disable 
 
 
 echo "Deleting GKE clusters..."

--- a/multi-environments-kustomize/install-config-sync.sh
+++ b/multi-environments-kustomize/install-config-sync.sh
@@ -59,7 +59,7 @@ fi
 echo "🔁 Installing ConfigSync on the dev cluster..."
 gcloud config set project $DEV_PROJECT
 kubectl config use-context $DEV_CTX
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
     --membership=dev \
     --config="$CM_CONFIG_DIR/install-config/config-management-dev.yaml" \
     --project=${DEV_PROJECT}
@@ -67,7 +67,7 @@ gcloud alpha container hub config-management apply \
 echo "🔁 Installing ConfigSync on the prod cluster..."
 gcloud config set project $PROD_PROJECT
 kubectl config use-context $PROD_CTX
-gcloud alpha container hub config-management apply \
+gcloud beta container fleet config-management apply \
     --membership=prod \
     --config="$CM_CONFIG_DIR/install-config/config-management-prod.yaml" \
     --project=${PROD_PROJECT}

--- a/multi-environments-kustomize/register-clusters.sh
+++ b/multi-environments-kustomize/register-clusters.sh
@@ -55,13 +55,13 @@ gcloud iam service-accounts keys create dev-key.json \
   --project=${DEV_PROJECT}
 
 URI="https://container.googleapis.com/v1/projects/${DEV_PROJECT}/zones/${DEV_CLUSTER_ZONE}/clusters/dev"
-gcloud container hub memberships register dev \
+gcloud container fleet memberships register dev \
     --project=${DEV_PROJECT} \
     --gke-uri=${URI} \
     --service-account-key-file=dev-key.json
 
 gcloud config set project $DEV_PROJECT
-gcloud alpha container hub config-management enable
+gcloud beta container fleet config-management enable
 
 echo "🏁 Setting up project: ${PROD_PROJECT}"
 
@@ -78,13 +78,13 @@ gcloud iam service-accounts keys create prod-key.json \
   --project=${PROD_PROJECT}
 
 URI="https://container.googleapis.com/v1/projects/${PROD_PROJECT}/zones/${PROD_CLUSTER_ZONE}/clusters/prod"
-gcloud container hub memberships register prod \
+gcloud container fleet memberships register prod \
     --project=${PROD_PROJECT} \
     --gke-uri=${URI} \
     --service-account-key-file=prod-key.json
 
 gcloud config set project $PROD_PROJECT
-gcloud alpha container hub config-management enable
+gcloud beta container fleet config-management enable
 
 echo "⭐️ Done registering clusters."
 

--- a/namespace-inheritance/README.md
+++ b/namespace-inheritance/README.md
@@ -63,7 +63,7 @@ You can also configure the Git repository information in a config-management.yam
     ```
 1.  Apply the config-management.yaml file:
     ```console
-    gcloud alpha container hub config-management apply \
+    gcloud beta container fleet config-management apply \
         --membership=CLUSTER_NAME \
         --config=CONFIG_YAML_PATH \
         --project=PROJECT_ID
@@ -83,7 +83,7 @@ You can also configure the Git repository information in a config-management.yam
 ### Using gcloud
 Run the following command to get the status
 ```console
-gcloud alpha container hub config-management status --project=PROJECT_ID
+gcloud beta container fleet config-management status --project=PROJECT_ID
 ```
 Replace `PROJECT_ID` with your project's ID.
 

--- a/namespace-specific-policy/automated-rendering/README.md
+++ b/namespace-specific-policy/automated-rendering/README.md
@@ -163,7 +163,7 @@ You can also configure the Git repository information in a
 1. Apply the `config-management.yaml` file.
 
    ```
-   gcloud alpha container hub config-management apply \
+   gcloud beta container fleet config-management apply \
    --membership=CLUSTER_NAME \
    --config=config-management.yaml \
    --project=PROJECT_ID

--- a/namespace-specific-policy/manual-rendering/README.md
+++ b/namespace-specific-policy/manual-rendering/README.md
@@ -151,7 +151,7 @@ You can also configure the Git repository information in a
 1. Apply the `config-management.yaml` file.
 
    ```
-   gcloud alpha container hub config-management apply \
+   gcloud beta container fleet config-management apply \
    --membership=CLUSTER_NAME \
    --config=config-management.yaml \
    --project=PROJECT_ID


### PR DESCRIPTION
Feedback reported by ACM PM while following the https://github.com/GoogleCloudPlatform/anthos-config-management-samples/tree/main/multi-cluster-acm-setup guide.

2 changes:
- `alpha` --> [`beta`](https://cloud.google.com/sdk/gcloud/reference/beta/container/hub/config-management)
- `hub` --> `fleet` (to be consistent with recommendation and docs, see https://github.com/GoogleCloudPlatform/anthos-config-management-samples/pull/66#issuecomment-1335382090 for more details)