### PR TITLE
no default namespace policy added

### DIFF
--- a/quickstart/config-sync/policies/no-default-namespace.yaml
+++ b/quickstart/config-sync/policies/no-default-namespace.yaml
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# [START anthosconfig_quickstart_policies_no_default_namespace] 
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sRestrictNamespaces
+metadata:
+  name: no-default-ns
+spec:
+  parameters:
+    restrictedNamespaces:
+    - default

--- a/quickstart/config-sync/policies/no-default-namespace.yaml
+++ b/quickstart/config-sync/policies/no-default-namespace.yaml
@@ -20,3 +20,4 @@ spec:
   parameters:
     restrictedNamespaces:
     - default
+# [START anthosconfig_quickstart_policies_no_default_namespace] 


### PR DESCRIPTION
In the quickstart, add a policy which does not allow to use default namespace.