### PR TITLE
Update ACM CRD for v1.17.1

### DIFF
--- a/crds/configmanagement_v1_configmanagement.yaml
+++ b/crds/configmanagement_v1_configmanagement.yaml
@@ -160,19 +160,15 @@ spec:
                     pattern: ^(ssh|cookiefile|gcenode|gcpserviceaccount|token|none)$
                     type: string
                   syncBranch:
-                    description: SyncBranch is the git branch to sync from. When `spec.enableMultiRepo`
-                      is true, `syncBranch` defaults to using the git server's default
-                      branch, unless `syncRev` is set, then `syncRev` takes precedence
-                      over `syncBranch`. It is recommended to use the `syncRev` field.
-                      When `spec.enableMultiRepo` is false, `syncBranch` defaults
-                      to `master`.
+                    description: 'SyncBranch is the branch to sync from.  Default:
+                      "master".'
                     type: string
                   syncRepo:
                     pattern: ^(((https?|git|ssh):\/\/)|git@)
                     type: string
                   syncRev:
-                    description: 'SyncRev is the git revision (branch, tag or hash)
-                      to fetch. Default: HEAD.'
+                    description: 'SyncRev is the git revision (tag or hash) to check
+                      out. Default: HEAD.'
                     type: string
                   syncWait:
                     description: 'SyncWaitSeconds is the time duration in seconds


### PR DESCRIPTION
Revert syncBranch and syncRev description, because monorepo still uses git-sync v3, not v4 like multirepo.

b/315804033